### PR TITLE
fix: GPS 轨迹缓存键纳入围栏与时间区间 (#2)

### DIFF
--- a/Mobile/mobile_app/lib/core/data/generators/gps_trajectory_generator.dart
+++ b/Mobile/mobile_app/lib/core/data/generators/gps_trajectory_generator.dart
@@ -9,13 +9,26 @@ class GpsTrajectoryGenerator {
   final int seed;
   final Map<String, List<GeoPoint>> _cache = {};
 
+  static String _cacheKey(
+    String earTag,
+    List<LatLng> fenceBoundary,
+    DateTime start,
+    DateTime end,
+  ) {
+    final fenceFp = Object.hashAll(
+      fenceBoundary.map((p) => Object.hash(p.latitude, p.longitude)),
+    );
+    return '$earTag|$fenceFp|${start.millisecondsSinceEpoch}|${end.millisecondsSinceEpoch}';
+  }
+
   List<GeoPoint> generate({
     required String earTag,
     required List<LatLng> fenceBoundary,
     required DateTime start,
     required DateTime end,
   }) {
-    return _cache.putIfAbsent(earTag, () => _doGenerate(
+    final key = _cacheKey(earTag, fenceBoundary, start, end);
+    return _cache.putIfAbsent(key, () => _doGenerate(
           earTag: earTag,
           fenceBoundary: fenceBoundary,
           start: start,

--- a/Mobile/mobile_app/test/generator_test.dart
+++ b/Mobile/mobile_app/test/generator_test.dart
@@ -44,7 +44,7 @@ void main() {
       }
     });
 
-    test('results are cached per earTag', () {
+    test('results are cached for identical earTag, fence, and range', () {
       final gen = GpsTrajectoryGenerator(seed: 42);
       const fence = [
         LatLng(28.2305, 112.9400),
@@ -63,6 +63,30 @@ void main() {
         end: DateTime.utc(2026, 4, 8),
       );
       expect(identical(a, b), isTrue);
+    });
+
+    test('different time ranges use separate cache entries', () {
+      final gen = GpsTrajectoryGenerator(seed: 42);
+      const fence = [
+        LatLng(28.2305, 112.9400),
+        LatLng(28.2340, 112.9440),
+      ];
+      final end = DateTime.utc(2026, 4, 8, 10);
+      final day24 = gen.generate(
+        earTag: 'SL-2024-001',
+        fenceBoundary: fence,
+        start: end.subtract(const Duration(hours: 24)),
+        end: end,
+      );
+      final week7 = gen.generate(
+        earTag: 'SL-2024-001',
+        fenceBoundary: fence,
+        start: end.subtract(const Duration(days: 7)),
+        end: end,
+      );
+      expect(day24.length, 24);
+      expect(week7.length, 168);
+      expect(identical(day24, week7), isFalse);
     });
   });
 


### PR DESCRIPTION
## 说明
- `GpsTrajectoryGenerator` 缓存键由「仅 earTag」改为 **earTag + 围栏顶点指纹 + start/end 毫秒**，同一牛只切换 24h / 7d / 30d 时命中不同缓存条目。
- 新增单测：24h 与 7d 点数分别为 24 与 168，且非同一列表引用。

## 关联
Closes https://github.com/aime4eve/smart-livestock/issues/2

## 验证
- `flutter analyze`
- `flutter test`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change limited to demo-data generation: it only adjusts in-memory caching behavior to avoid returning trajectories generated for a different fence or time window.
> 
> **Overview**
> **Fixes incorrect GPS trajectory cache hits.** `GpsTrajectoryGenerator` now keys its in-memory cache by `earTag` plus a hash of `fenceBoundary` and `start`/`end` timestamps, instead of just `earTag`.
> 
> **Tests updated/added** to assert identical inputs return the same cached list, while different time ranges (e.g., 24h vs 7d) produce different cache entries and expected point counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff8bfa673f4c7b9cfe5942bd188c4b33227e2653. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->