### PR TITLE
feat(mobile): 孪生 demo 对齐与设备列表（#3–#7）及 Web Live 体验

### DIFF
--- a/Mobile/backend/data/seed.js
+++ b/Mobile/backend/data/seed.js
@@ -179,4 +179,55 @@ const tenants = [
   { id: 'tenant_002', name: '西部高原牧场', status: 'active', licenseUsed: 120, licenseTotal: 200 },
 ];
 
-module.exports = { users, dashboardMetrics, animals, fences, alerts, tenants };
+function generateDevices() {
+  const result = [];
+  function addBatch(count, idPrefix, type, namePrefix, onlineCount, offlineCount, lowBatteryCount) {
+    for (let i = 1; i <= count; i++) {
+      const id = `${idPrefix}-${i.toString().padStart(3, '0')}`;
+      const name = `${namePrefix}-${i.toString().padStart(3, '0')}`;
+      const earTag = `SL-2024-${i.toString().padStart(3, '0')}`;
+      let status;
+      if (i <= onlineCount) {
+        status = 'online';
+      } else if (i <= onlineCount + offlineCount) {
+        status = 'offline';
+      } else {
+        status = 'lowBattery';
+      }
+      let batteryPercent;
+      let signalStrength;
+      let lastSync;
+      if (status === 'online') {
+        batteryPercent = 60 + ((i * 3) % 35);
+        signalStrength = i % 3 === 0 ? '中' : '强';
+        lastSync = `${1 + (i % 5)} 分钟前`;
+      } else if (status === 'lowBattery') {
+        batteryPercent = 5 + (i % 10);
+        signalStrength = '弱';
+        lastSync = `${10 + (i % 20)} 分钟前`;
+      } else {
+        batteryPercent = null;
+        signalStrength = '无';
+        lastSync = `${1 + (i % 6)} 小时前`;
+      }
+      result.push({
+        id,
+        name,
+        type,
+        status,
+        boundEarTag: earTag,
+        batteryPercent,
+        signalStrength,
+        lastSync,
+      });
+    }
+  }
+  addBatch(50, 'DEV-GPS', 'gps', 'GPS追踪器', 42, 4, 4);
+  addBatch(30, 'DEV-RC', 'rumenCapsule', '瘤胃胶囊', 26, 2, 2);
+  addBatch(20, 'DEV-ACC', 'accelerometer', '加速度计', 17, 2, 1);
+  return result;
+}
+
+const devices = generateDevices();
+
+module.exports = { users, dashboardMetrics, animals, fences, alerts, tenants, devices };

--- a/Mobile/backend/data/twin_seed.js
+++ b/Mobile/backend/data/twin_seed.js
@@ -1,4 +1,8 @@
 const overview = {
+  pastureBanner: {
+    headline: '当前演示牧区',
+    detail: '本分区含 50 头演示个体；下方牲畜总数等指标为集团孪生汇总口径。',
+  },
   stats: {
     totalLivestock: 3847,
     healthyRate: 99.1,
@@ -25,8 +29,127 @@ const overview = {
   ],
 };
 
-function tempPoint(t, temp) {
-  return { temperature: temp, timestamp: t };
+function mulberry32(a) {
+  return function () {
+    let t = (a += 0x6d2b79f5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function hashCodeStr(s) {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) {
+    h = (Math.imul(31, h) + s.charCodeAt(i)) | 0;
+  }
+  return h >>> 0;
+}
+
+function reduceTemperatureToHourlyMean(points) {
+  const groups = new Map();
+  for (const p of points) {
+    const d = new Date(p.timestamp);
+    const k = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate(), d.getUTCHours());
+    if (!groups.has(k)) groups.set(k, []);
+    groups.get(k).push(p.temperature);
+  }
+  const keys = [...groups.keys()].sort((a, b) => a - b);
+  return keys.map((k) => ({
+    temperature: +(groups.get(k).reduce((s, x) => s + x, 0) / groups.get(k).length).toFixed(2),
+    timestamp: new Date(k).toISOString(),
+  }));
+}
+
+function buildThirtyMinuteTempSeries(livestockId, baselineTemp, status) {
+  const rng = mulberry32((hashCodeStr(livestockId) + 42) >>> 0);
+  const records = [];
+  const start = Date.UTC(2026, 3, 1);
+  const end = Date.UTC(2026, 3, 8);
+  for (let t = start; t < end; t += 30 * 60 * 1000) {
+    const d = new Date(t);
+    const hour = d.getUTCHours();
+    const circadian = hour >= 8 && hour <= 18 ? 0.2 : -0.1;
+    const noise = (rng() - 0.5) * 0.2;
+    let temp = baselineTemp + circadian + noise;
+    if (status === 'critical') {
+      const spike = (t - Date.UTC(2026, 3, 5, 10)) / (1000 * 60 * 60);
+      if (spike >= 0 && spike < 48) {
+        const progress = spike / 48;
+        const envelope = progress < 0.3 ? progress / 0.3 : 1 - (progress - 0.3) / 0.7;
+        temp += 1.5 * envelope;
+      }
+    } else if (status === 'warning') {
+      const spike = (t - Date.UTC(2026, 3, 6, 14)) / (1000 * 60 * 60);
+      if (spike >= 0 && spike < 24) {
+        const progress = spike / 24;
+        const envelope = progress < 0.3 ? progress / 0.3 : 1 - (progress - 0.3) / 0.7;
+        temp += 0.6 * envelope;
+      }
+    }
+    records.push({
+      temperature: +temp.toFixed(2),
+      timestamp: d.toISOString(),
+    });
+  }
+  return reduceTemperatureToHourlyMean(records);
+}
+
+function reduceMotilityToHourlyMean(points) {
+  const freqG = new Map();
+  const intG = new Map();
+  for (const p of points) {
+    const d = new Date(p.timestamp);
+    const k = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate(), d.getUTCHours());
+    if (!freqG.has(k)) {
+      freqG.set(k, []);
+      intG.set(k, []);
+    }
+    freqG.get(k).push(p.frequency);
+    intG.get(k).push(p.intensity);
+  }
+  const keys = [...freqG.keys()].sort((a, b) => a - b);
+  return keys.map((k) => ({
+    frequency: +(freqG.get(k).reduce((s, x) => s + x, 0) / freqG.get(k).length).toFixed(2),
+    intensity: +(intG.get(k).reduce((s, x) => s + x, 0) / intG.get(k).length).toFixed(2),
+    timestamp: new Date(k).toISOString(),
+  }));
+}
+
+function buildThirtyMinuteMotilitySeries(livestockId, healthLevel) {
+  const rng = mulberry32((hashCodeStr(`${livestockId}_${healthLevel}`) + 42) >>> 0);
+  const records = [];
+  const start = Date.UTC(2026, 3, 1);
+  const end = Date.UTC(2026, 3, 8);
+  for (let t = start; t < end; t += 30 * 60 * 1000) {
+    const d = new Date(t);
+    const hour = d.getUTCHours();
+    let baseRpm;
+    if ((hour >= 6 && hour < 10) || (hour >= 16 && hour < 20)) {
+      baseRpm = 1.1 + rng() * 0.45;
+    } else if (hour >= 23 || hour < 5) {
+      baseRpm = 0.72 + rng() * 0.32;
+    } else {
+      baseRpm = 0.92 + rng() * 0.42;
+    }
+    let freq = baseRpm + (rng() - 0.5) * 0.14;
+    if (healthLevel === 'critical') {
+      freq *= 0.06 + rng() * 0.14;
+      if (rng() < 0.38) {
+        freq = 0;
+      }
+    } else if (healthLevel === 'warning') {
+      freq *= 0.38 + rng() * 0.22;
+    }
+    freq = Math.min(2.2, Math.max(0, freq));
+    const intensity = freq > 0.12 ? 0.45 + rng() * 0.45 : 0;
+    records.push({
+      frequency: +freq.toFixed(2),
+      intensity: +intensity.toFixed(2),
+      timestamp: d.toISOString(),
+    });
+  }
+  return reduceMotilityToHourlyMean(records);
 }
 
 function buildFeverList() {
@@ -52,14 +175,7 @@ function buildFeverList() {
       threshold: +(base + 0.5).toFixed(1),
       status,
       conclusion,
-      recent72h: [
-        tempPoint('2026-04-05T10:00:00Z', base),
-        tempPoint('2026-04-06T10:00:00Z', status === 'critical' ? base + 1.0 : base + 0.1),
-        tempPoint(
-          '2026-04-07T10:00:00Z',
-          status === 'critical' ? base + 1.5 : status === 'warning' ? base + 0.5 : base + 0.05,
-        ),
-      ],
+      recent72h: buildThirtyMinuteTempSeries(id, base, status),
     });
   }
   return result;
@@ -74,28 +190,26 @@ function buildDigestiveList() {
     const base = 1.3 + (i % 5) * 0.05;
     let status;
     let advice;
+    let healthLevel;
     if (i >= 29) {
       status = 'critical';
       advice = '蠕动完全停止，疑似瘤胃臌气，需立即处理';
+      healthLevel = 'critical';
     } else if (i >= 26) {
       status = 'warning';
       advice = '蠕动频率下降，建议检查饲粮与饮水';
+      healthLevel = 'warning';
     } else {
       status = 'normal';
       advice = '蠕动节律正常';
+      healthLevel = 'normal';
     }
     result.push({
       livestockId: id,
       motilityBaseline: +base.toFixed(2),
       status,
       advice,
-      recent24h: [
-        {
-          frequency: status === 'critical' ? 0 : base,
-          intensity: status === 'critical' ? 0 : 0.8,
-          timestamp: '2026-04-07T10:00:00Z',
-        },
-      ],
+      recent24h: buildThirtyMinuteMotilitySeries(id, healthLevel),
     });
   }
   return result;

--- a/Mobile/backend/routes/devices.js
+++ b/Mobile/backend/routes/devices.js
@@ -1,0 +1,21 @@
+const { Router } = require('express');
+const { devices } = require('../data/seed');
+const { authMiddleware, requirePermission } = require('../middleware/auth');
+
+const router = Router();
+
+router.get(
+  '/',
+  authMiddleware,
+  requirePermission('dashboard:view'),
+  (req, res) => {
+    res.ok({
+      items: devices,
+      page: 1,
+      pageSize: devices.length,
+      total: devices.length,
+    });
+  },
+);
+
+module.exports = router;

--- a/Mobile/backend/server.js
+++ b/Mobile/backend/server.js
@@ -12,6 +12,7 @@ const fencesRoutes = require('./routes/fences');
 const tenantsRoutes = require('./routes/tenants');
 const profileRoutes = require('./routes/profile');
 const twinRoutes = require('./routes/twin');
+const devicesRoutes = require('./routes/devices');
 
 const app = express();
 const PORT = 3001;
@@ -31,6 +32,7 @@ app.use('/api/fences', fencesRoutes);
 app.use('/api/tenants', tenantsRoutes);
 app.use('/api/profile', profileRoutes);
 app.use('/api/twin', twinRoutes);
+app.use('/api/devices', devicesRoutes);
 
 // 404 fallback
 app.use((req, res) => {
@@ -66,6 +68,7 @@ const ROUTE_TABLE = [
   ['GET',    '/api/twin/estrus/:id'],
   ['GET',    '/api/twin/epidemic/summary'],
   ['GET',    '/api/twin/epidemic/contacts'],
+  ['GET',    '/api/devices'],
 ];
 
 // Start server

--- a/Mobile/mobile_app/README.md
+++ b/Mobile/mobile_app/README.md
@@ -17,4 +17,14 @@ flutter run
 flutter run --dart-define=APP_MODE=live
 ```
 
+### Live 联调（含 `flutter run -d chrome`）
+
+1. **先启动 Mock API**（默认 `http://localhost:3001`）：  
+   `cd ../backend && node server.js`  
+   或使用 `../dev.sh start live chrome` 一键拉起后端 + 应用。
+2. **再**执行 `flutter run -d chrome --dart-define=APP_MODE=live`。  
+   Web 端默认请求 `http://127.0.0.1:3001/api`，避免浏览器将 `localhost` 解析到 IPv6 导致连不上本机 Node。若仍失败，可显式指定：  
+   `--dart-define=API_BASE_URL=http://127.0.0.1:3001/api`
+3. Live 模式下 `main` 会预拉取接口；后端未启动时会在控制台出现 `ApiCache init failed`，多数页面会回退到 Mock 数据，体验与真联调不一致。
+
 详细目录结构、测试约定与主题规范见 [`../AGENTS.md`](../AGENTS.md)。

--- a/Mobile/mobile_app/lib/app/url_strategy.dart
+++ b/Mobile/mobile_app/lib/app/url_strategy.dart
@@ -1,0 +1,2 @@
+export 'url_strategy_stub.dart'
+    if (dart.library.html) 'url_strategy_web.dart';

--- a/Mobile/mobile_app/lib/app/url_strategy_stub.dart
+++ b/Mobile/mobile_app/lib/app/url_strategy_stub.dart
@@ -1,0 +1,1 @@
+void configureUrlStrategyIfWeb() {}

--- a/Mobile/mobile_app/lib/app/url_strategy_web.dart
+++ b/Mobile/mobile_app/lib/app/url_strategy_web.dart
@@ -1,0 +1,5 @@
+import 'package:flutter_web_plugins/url_strategy.dart';
+
+void configureUrlStrategyIfWeb() {
+  usePathUrlStrategy();
+}

--- a/Mobile/mobile_app/lib/core/api/api_cache.dart
+++ b/Mobile/mobile_app/lib/core/api/api_cache.dart
@@ -2,10 +2,17 @@ import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 
-const String _apiBaseUrl = String.fromEnvironment(
+const String _apiBaseUrlFromEnv = String.fromEnvironment(
   'API_BASE_URL',
-  defaultValue: 'http://localhost:3001/api',
+  defaultValue: '',
 );
+
+String _resolveApiBaseUrl() {
+  if (_apiBaseUrlFromEnv.isNotEmpty) {
+    return _apiBaseUrlFromEnv;
+  }
+  return kIsWeb ? 'http://127.0.0.1:3001/api' : 'http://localhost:3001/api';
+}
 
 class ApiCache {
   ApiCache._();
@@ -148,10 +155,12 @@ class ApiCache {
     String path,
     Map<String, String> headers,
   ) async {
-    final response = await http.get(
-      Uri.parse('$_apiBaseUrl$path'),
-      headers: headers,
-    );
+    final response = await http
+        .get(
+          Uri.parse('${_resolveApiBaseUrl()}$path'),
+          headers: headers,
+        )
+        .timeout(const Duration(seconds: 20));
     if (response.statusCode == 200) {
       final body = jsonDecode(response.body) as Map<String, dynamic>;
       if (body['code'] == 'OK') {

--- a/Mobile/mobile_app/lib/core/api/api_cache.dart
+++ b/Mobile/mobile_app/lib/core/api/api_cache.dart
@@ -28,6 +28,7 @@ class ApiCache {
   List<Map<String, dynamic>> _estrusList = [];
   Map<String, dynamic>? _epidemicSummary;
   List<Map<String, dynamic>> _epidemicContacts = [];
+  List<Map<String, dynamic>> _devices = [];
 
   List<Map<String, dynamic>> get dashboardMetrics => _dashboardMetrics;
   List<Map<String, dynamic>> get animals => _animals;
@@ -43,6 +44,7 @@ class ApiCache {
   List<Map<String, dynamic>> get estrusList => _estrusList;
   Map<String, dynamic>? get epidemicSummary => _epidemicSummary;
   List<Map<String, dynamic>> get epidemicContacts => _epidemicContacts;
+  List<Map<String, dynamic>> get devices => _devices;
 
   Future<void> init(String role) async {
     final token = 'mock-token-$role';
@@ -65,6 +67,7 @@ class ApiCache {
         _get('/twin/estrus/list', headers),
         _get('/twin/epidemic/summary', headers),
         _get('/twin/epidemic/contacts', headers),
+        _get('/devices?pageSize=200', headers),
       ]);
 
       final dashData = results[0];
@@ -127,6 +130,12 @@ class ApiCache {
       if (contactsData != null) {
         _epidemicContacts =
             List<Map<String, dynamic>>.from(contactsData['items'] ?? []);
+      }
+
+      final devicesData = results[12];
+      if (devicesData != null) {
+        _devices =
+            List<Map<String, dynamic>>.from(devicesData['items'] ?? []);
       }
 
       _initialized = true;

--- a/Mobile/mobile_app/lib/core/data/twin_seed.dart
+++ b/Mobile/mobile_app/lib/core/data/twin_seed.dart
@@ -1,10 +1,15 @@
 import 'package:smart_livestock_demo/core/data/generators/estrus_score_generator.dart';
 import 'package:smart_livestock_demo/core/data/generators/motility_generator.dart';
 import 'package:smart_livestock_demo/core/data/generators/temperature_generator.dart';
+import 'package:smart_livestock_demo/core/data/twin_series_downsample.dart';
 import 'package:smart_livestock_demo/core/models/twin_models.dart';
 
 class TwinSeed {
   const TwinSeed._();
+
+  static const String overviewPastureHeadline = '当前演示牧区';
+  static const String overviewPastureDetail =
+      '本分区含 50 头演示个体；下方牲畜总数等指标为集团孪生汇总口径。';
 
   static final _tempGen = TemperatureGenerator(seed: 42);
   static final _motilityGen = MotilityGenerator(seed: 42);
@@ -134,12 +139,14 @@ class TwinSeed {
         livestockId: id,
         baselineTemp: double.parse(baseTemp.toStringAsFixed(1)),
         threshold: double.parse((baseTemp + 0.5).toStringAsFixed(1)),
-        recent72h: _tempGen.generate(
-          livestockId: id,
-          baselineTemp: baseTemp,
-          start: _start,
-          end: _end,
-          abnormalEvents: events,
+        recent72h: TwinSeriesDownsample.hourlyMeanTemperature(
+          _tempGen.generate(
+            livestockId: id,
+            baselineTemp: baseTemp,
+            start: _start,
+            end: _end,
+            abnormalEvents: events,
+          ),
         ),
         status: status,
         conclusion: conclusion,
@@ -177,11 +184,13 @@ class TwinSeed {
         motilityBaseline: double.parse(baseMot.toStringAsFixed(2)),
         status: status,
         advice: advice,
-        recent24h: _motilityGen.generate(
-          livestockId: id,
-          healthLevel: healthLevel,
-          start: _start,
-          end: _end,
+        recent24h: TwinSeriesDownsample.hourlyMeanMotility(
+          _motilityGen.generate(
+            livestockId: id,
+            healthLevel: healthLevel,
+            start: _start,
+            end: _end,
+          ),
         ),
       ));
     }

--- a/Mobile/mobile_app/lib/core/data/twin_seed.dart
+++ b/Mobile/mobile_app/lib/core/data/twin_seed.dart
@@ -101,7 +101,7 @@ class TwinSeed {
 
   static List<TemperatureBaseline> _buildFeverBaselines() {
     final result = <TemperatureBaseline>[];
-    for (var i = 1; i <= 30; i++) {
+    for (var i = 1; i <= 50; i++) {
       final id = i.toString().padLeft(4, '0');
       final baseTemp = 38.0 + (i % 6) * 0.25;
 
@@ -157,7 +157,7 @@ class TwinSeed {
 
   static List<DigestiveHealth> _buildDigestiveItems() {
     final result = <DigestiveHealth>[];
-    for (var i = 1; i <= 30; i++) {
+    for (var i = 1; i <= 50; i++) {
       final id = i.toString().padLeft(4, '0');
       final baseMot = 1.12 + (i % 5) * 0.07;
 

--- a/Mobile/mobile_app/lib/core/data/twin_series_downsample.dart
+++ b/Mobile/mobile_app/lib/core/data/twin_series_downsample.dart
@@ -1,0 +1,120 @@
+import 'package:smart_livestock_demo/core/models/twin_models.dart';
+
+class TwinSeriesDownsample {
+  const TwinSeriesDownsample._();
+
+  static DateTime _hourStartUtc(DateTime t) =>
+      DateTime.utc(t.year, t.month, t.day, t.hour);
+
+  static List<TemperatureRecord> hourlyMeanTemperature(
+    List<TemperatureRecord> input, {
+    int maxPoints = 200,
+  }) {
+    if (input.isEmpty) return input;
+    final id = input.first.livestockId;
+    final buckets = <DateTime, List<double>>{};
+    for (final r in input) {
+      final k = _hourStartUtc(r.timestamp);
+      (buckets[k] ??= []).add(r.temperature);
+    }
+    final keys = buckets.keys.toList()..sort();
+    final merged = <TemperatureRecord>[];
+    for (final k in keys) {
+      final xs = buckets[k]!;
+      final mean = xs.reduce((a, b) => a + b) / xs.length;
+      merged.add(
+        TemperatureRecord(
+          livestockId: id,
+          temperature: double.parse(mean.toStringAsFixed(2)),
+          timestamp: k,
+        ),
+      );
+    }
+    if (merged.length <= maxPoints) return merged;
+    return _uniformCapTemperature(merged, maxPoints);
+  }
+
+  static List<TemperatureRecord> _uniformCapTemperature(
+    List<TemperatureRecord> list,
+    int maxPoints,
+  ) {
+    if (list.length <= maxPoints) return list;
+    if (maxPoints < 2) {
+      return [list.last];
+    }
+    final id = list.first.livestockId;
+    final step = (list.length - 1) / (maxPoints - 1);
+    final out = <TemperatureRecord>[];
+    for (var i = 0; i < maxPoints; i++) {
+      final idx = (i * step).floor().clamp(0, list.length - 1);
+      final r = list[idx];
+      out.add(
+        TemperatureRecord(
+          livestockId: id,
+          temperature: r.temperature,
+          timestamp: r.timestamp,
+        ),
+      );
+    }
+    return out;
+  }
+
+  static List<MotilityRecord> hourlyMeanMotility(
+    List<MotilityRecord> input, {
+    int maxPoints = 200,
+  }) {
+    if (input.isEmpty) return input;
+    final id = input.first.livestockId;
+    final freqBuckets = <DateTime, List<double>>{};
+    final intBuckets = <DateTime, List<double>>{};
+    for (final r in input) {
+      final k = _hourStartUtc(r.timestamp);
+      (freqBuckets[k] ??= []).add(r.frequency);
+      (intBuckets[k] ??= []).add(r.intensity);
+    }
+    final keys = freqBuckets.keys.toList()..sort();
+    final merged = <MotilityRecord>[];
+    for (final k in keys) {
+      final fs = freqBuckets[k]!;
+      final ins = intBuckets[k]!;
+      final fMean = fs.reduce((a, b) => a + b) / fs.length;
+      final iMean = ins.reduce((a, b) => a + b) / ins.length;
+      merged.add(
+        MotilityRecord(
+          livestockId: id,
+          frequency: double.parse(fMean.toStringAsFixed(2)),
+          intensity: double.parse(iMean.toStringAsFixed(2)),
+          timestamp: k,
+        ),
+      );
+    }
+    if (merged.length <= maxPoints) return merged;
+    return _uniformCapMotility(merged, maxPoints);
+  }
+
+  static List<MotilityRecord> _uniformCapMotility(
+    List<MotilityRecord> list,
+    int maxPoints,
+  ) {
+    if (list.length <= maxPoints) return list;
+    if (maxPoints < 2) {
+      return [list.last];
+    }
+    final id = list.first.livestockId;
+    final step = (list.length - 1) / (maxPoints - 1);
+    final out = <MotilityRecord>[];
+    for (var i = 0; i < maxPoints; i++) {
+      final idx = (i * step).floor().clamp(0, list.length - 1);
+      final r = list[idx];
+      out.add(
+        MotilityRecord(
+          livestockId: id,
+          frequency: r.frequency,
+          intensity: r.intensity,
+          timestamp: r.timestamp,
+        ),
+      );
+    }
+    return out;
+  }
+}

--- a/Mobile/mobile_app/lib/core/models/twin_models.dart
+++ b/Mobile/mobile_app/lib/core/models/twin_models.dart
@@ -23,6 +23,8 @@ class TwinOverviewViewData {
     this.sceneSummary,
     this.pendingTasks = const [],
     this.message,
+    this.pastureHeadline,
+    this.pastureDetail,
   });
 
   final ViewState viewState;
@@ -30,6 +32,8 @@ class TwinOverviewViewData {
   final TwinSceneSummary? sceneSummary;
   final List<TwinPendingTask> pendingTasks;
   final String? message;
+  final String? pastureHeadline;
+  final String? pastureDetail;
 }
 
 class TwinOverviewStats {

--- a/Mobile/mobile_app/lib/features/devices/data/live_devices_repository.dart
+++ b/Mobile/mobile_app/lib/features/devices/data/live_devices_repository.dart
@@ -1,13 +1,72 @@
+import 'package:smart_livestock_demo/core/api/api_cache.dart';
 import 'package:smart_livestock_demo/core/models/demo_models.dart';
 import 'package:smart_livestock_demo/core/models/view_state.dart';
+import 'package:smart_livestock_demo/features/devices/data/mock_devices_repository.dart';
 import 'package:smart_livestock_demo/features/devices/domain/devices_repository.dart';
 
 class LiveDevicesRepository implements DevicesRepository {
   const LiveDevicesRepository();
 
+  static const MockDevicesRepository _fallback = MockDevicesRepository();
+
+  static DeviceItem? parseDeviceMap(Map<String, dynamic> m) {
+    try {
+      final typeStr = m['type'] as String;
+      final type = switch (typeStr) {
+        'gps' => DeviceType.gps,
+        'rumenCapsule' => DeviceType.rumenCapsule,
+        'accelerometer' => DeviceType.accelerometer,
+        _ => throw const FormatException('type'),
+      };
+      final statusStr = m['status'] as String;
+      final status = switch (statusStr) {
+        'online' => DeviceStatus.online,
+        'offline' => DeviceStatus.offline,
+        'lowBattery' => DeviceStatus.lowBattery,
+        _ => throw const FormatException('status'),
+      };
+      return DeviceItem(
+        id: m['id'] as String,
+        name: m['name'] as String,
+        type: type,
+        status: status,
+        boundEarTag: m['boundEarTag'] as String,
+        batteryPercent: (m['batteryPercent'] as num?)?.toInt(),
+        signalStrength: m['signalStrength'] as String?,
+        lastSync: m['lastSync'] as String?,
+      );
+    } catch (_) {
+      return null;
+    }
+  }
+
   @override
-  DevicesViewData load(
-      {required ViewState viewState, required DeviceStatus? filter}) {
-    return DevicesViewData(viewState: viewState, devices: [], filter: filter);
+  DevicesViewData load({
+    required ViewState viewState,
+    required DeviceStatus? filter,
+  }) {
+    final cache = ApiCache.instance;
+    if (!cache.initialized || cache.devices.isEmpty) {
+      return _fallback.load(viewState: viewState, filter: filter);
+    }
+    final all = cache.devices
+        .map(parseDeviceMap)
+        .whereType<DeviceItem>()
+        .toList();
+    final filtered =
+        filter == null ? all : all.where((d) => d.status == filter).toList();
+    return DevicesViewData(
+      viewState: viewState,
+      devices: viewState == ViewState.normal ? filtered : [],
+      filter: filter,
+      message: switch (viewState) {
+        ViewState.loading => '加载中',
+        ViewState.empty => '暂无设备',
+        ViewState.error => '设备列表加载失败',
+        ViewState.forbidden => '无权限查看设备',
+        ViewState.offline => '离线设备快照',
+        ViewState.normal => null,
+      },
+    );
   }
 }

--- a/Mobile/mobile_app/lib/features/digestive/data/live_digestive_repository.dart
+++ b/Mobile/mobile_app/lib/features/digestive/data/live_digestive_repository.dart
@@ -1,4 +1,5 @@
 import 'package:smart_livestock_demo/core/api/api_cache.dart';
+import 'package:smart_livestock_demo/core/data/twin_series_downsample.dart';
 import 'package:smart_livestock_demo/core/models/twin_models.dart';
 import 'package:smart_livestock_demo/core/models/view_state.dart';
 import 'package:smart_livestock_demo/features/digestive/data/mock_digestive_repository.dart';
@@ -63,7 +64,7 @@ class LiveDigestiveRepository implements DigestiveRepository {
         motilityBaseline: (m['motilityBaseline'] as num).toDouble(),
         status: m['status'] as String,
         advice: m['advice'] as String?,
-        recent24h: records,
+        recent24h: TwinSeriesDownsample.hourlyMeanMotility(records),
       );
     } catch (_) {
       return null;

--- a/Mobile/mobile_app/lib/features/fever_warning/data/live_fever_repository.dart
+++ b/Mobile/mobile_app/lib/features/fever_warning/data/live_fever_repository.dart
@@ -1,4 +1,5 @@
 import 'package:smart_livestock_demo/core/api/api_cache.dart';
+import 'package:smart_livestock_demo/core/data/twin_series_downsample.dart';
 import 'package:smart_livestock_demo/core/models/twin_models.dart';
 import 'package:smart_livestock_demo/core/models/view_state.dart';
 import 'package:smart_livestock_demo/features/fever_warning/data/mock_fever_repository.dart';
@@ -64,7 +65,7 @@ class LiveFeverRepository implements FeverRepository {
         livestockId: id,
         baselineTemp: (m['baselineTemp'] as num).toDouble(),
         threshold: (m['threshold'] as num).toDouble(),
-        recent72h: records,
+        recent72h: TwinSeriesDownsample.hourlyMeanTemperature(records),
         status: m['status'] as String,
         conclusion: m['conclusion'] as String?,
       );

--- a/Mobile/mobile_app/lib/features/pages/digestive_page.dart
+++ b/Mobile/mobile_app/lib/features/pages/digestive_page.dart
@@ -135,7 +135,7 @@ class DigestivePage extends ConsumerWidget {
                 key: Key('digestive-item-${item.livestockId}'),
                 item: item,
                 motilityLabel: _motilityLabel(item.status),
-                onTap: () => context.go(
+                onTap: () => context.push(
                   AppRoute.twinDigestiveDetail.path.replaceFirst(
                     ':livestockId',
                     item.livestockId,

--- a/Mobile/mobile_app/lib/features/pages/estrus_page.dart
+++ b/Mobile/mobile_app/lib/features/pages/estrus_page.dart
@@ -119,7 +119,7 @@ class EstrusPage extends ConsumerWidget {
               _EstrusListItem(
                 key: Key('estrus-item-${item.livestockId}'),
                 item: item,
-                onTap: () => context.go(
+                onTap: () => context.push(
                   AppRoute.twinEstrusDetail.path.replaceFirst(
                     ':livestockId',
                     item.livestockId,

--- a/Mobile/mobile_app/lib/features/pages/fever_warning_page.dart
+++ b/Mobile/mobile_app/lib/features/pages/fever_warning_page.dart
@@ -127,7 +127,7 @@ class FeverWarningPage extends ConsumerWidget {
               _FeverListItem(
                 key: Key('fever-item-${item.livestockId}'),
                 item: item,
-                onTap: () => context.go(
+                onTap: () => context.push(
                   AppRoute.twinFeverDetail.path.replaceFirst(
                     ':livestockId',
                     item.livestockId,

--- a/Mobile/mobile_app/lib/features/pages/twin_overview_page.dart
+++ b/Mobile/mobile_app/lib/features/pages/twin_overview_page.dart
@@ -171,7 +171,8 @@ class TwinOverviewPage extends ConsumerWidget {
                         title: Text(data.pendingTasks[i].title),
                         subtitle: Text(data.pendingTasks[i].subtitle),
                         trailing: const Icon(Icons.chevron_right),
-                        onTap: () => context.go(data.pendingTasks[i].routePath),
+                        onTap: () =>
+                            context.push(data.pendingTasks[i].routePath),
                       ),
                     ],
                   ],
@@ -193,7 +194,7 @@ class TwinOverviewPage extends ConsumerWidget {
                   value: _commaInt(stats.totalLivestock),
                   trend: stats.livestockTrend,
                   caption: stats.livestockCaption,
-                  onTap: () => context.go(AppRoute.twinEpidemic.path),
+                  onTap: () => context.push(AppRoute.twinEpidemic.path),
                 ),
                 HighfiStatTile(
                   title: '健康率',
@@ -207,7 +208,7 @@ class TwinOverviewPage extends ConsumerWidget {
                   value: '${stats.alertCount}',
                   caption: stats.alertCaption,
                   valueColor: alertColor,
-                  onTap: () => context.go(AppRoute.alerts.path),
+                  onTap: () => context.push(AppRoute.alerts.path),
                 ),
                 HighfiStatTile(
                   title: '设备在线',
@@ -226,7 +227,7 @@ class TwinOverviewPage extends ConsumerWidget {
               alertLevel: scene.fever.criticalCount > 0
                   ? 'critical'
                   : (scene.fever.abnormalCount > 0 ? 'warning' : null),
-              onTap: () => context.go(AppRoute.twinFever.path),
+              onTap: () => context.push(AppRoute.twinFever.path),
             ),
             const SizedBox(height: AppSpacing.md),
             TwinSceneCard(
@@ -238,7 +239,7 @@ class TwinOverviewPage extends ConsumerWidget {
               alertLevel: scene.digestive.abnormalCount > 0
                   ? 'critical'
                   : null,
-              onTap: () => context.go(AppRoute.twinDigestive.path),
+              onTap: () => context.push(AppRoute.twinDigestive.path),
             ),
             const SizedBox(height: AppSpacing.md),
             TwinSceneCard(
@@ -249,7 +250,7 @@ class TwinOverviewPage extends ConsumerWidget {
                   '${scene.estrus.highScoreCount} 头高分 · ${scene.estrus.breedingAdvice ? '建议配种' : '暂无需配种'}',
               alertLevel:
                   scene.estrus.highScoreCount > 0 ? 'warning' : null,
-              onTap: () => context.go(AppRoute.twinEstrus.path),
+              onTap: () => context.push(AppRoute.twinEstrus.path),
             ),
             const SizedBox(height: AppSpacing.md),
             TwinSceneCard(
@@ -259,7 +260,7 @@ class TwinOverviewPage extends ConsumerWidget {
               summary:
                   '${scene.epidemic.status == 'normal' ? '群体正常' : '需关注'} · 异常率 ${scene.epidemic.abnormalRate}%',
               alertLevel: null,
-              onTap: () => context.go(AppRoute.twinEpidemic.path),
+              onTap: () => context.push(AppRoute.twinEpidemic.path),
             ),
           ],
         );

--- a/Mobile/mobile_app/lib/features/pages/twin_overview_page.dart
+++ b/Mobile/mobile_app/lib/features/pages/twin_overview_page.dart
@@ -121,6 +121,30 @@ class TwinOverviewPage extends ConsumerWidget {
                 ],
               ),
             ),
+            if (data.pastureHeadline != null && data.pastureDetail != null) ...[
+              const SizedBox(height: AppSpacing.md),
+              HighfiCard(
+                key: const Key('twin-pasture-context'),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      data.pastureHeadline!,
+                      style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                        color: AppColors.textPrimary,
+                      ),
+                    ),
+                    const SizedBox(height: AppSpacing.sm),
+                    Text(
+                      data.pastureDetail!,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: AppColors.textSecondary,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
             if (data.pendingTasks.isNotEmpty) ...[
               const SizedBox(height: AppSpacing.md),
               HighfiCard(

--- a/Mobile/mobile_app/lib/features/twin_overview/data/live_twin_overview_repository.dart
+++ b/Mobile/mobile_app/lib/features/twin_overview/data/live_twin_overview_repository.dart
@@ -1,4 +1,5 @@
 import 'package:smart_livestock_demo/core/api/api_cache.dart';
+import 'package:smart_livestock_demo/core/data/twin_seed.dart';
 import 'package:smart_livestock_demo/core/models/twin_models.dart';
 import 'package:smart_livestock_demo/core/models/view_state.dart';
 import 'package:smart_livestock_demo/features/twin_overview/data/mock_twin_overview_repository.dart';
@@ -22,6 +23,14 @@ class LiveTwinOverviewRepository implements TwinOverviewRepository {
     if (statsMap == null || sceneMap == null) {
       return _fallback.load(desiredState);
     }
+
+    final banner = raw['pastureBanner'] as Map<String, dynamic>?;
+    final pastureHeadline = (banner?['headline'] as String?)?.trim().isNotEmpty == true
+        ? banner!['headline'] as String
+        : TwinSeed.overviewPastureHeadline;
+    final pastureDetail = (banner?['detail'] as String?)?.trim().isNotEmpty == true
+        ? banner!['detail'] as String
+        : TwinSeed.overviewPastureDetail;
 
     final fever = sceneMap['fever'] as Map<String, dynamic>?;
     final digestive = sceneMap['digestive'] as Map<String, dynamic>?;
@@ -83,6 +92,8 @@ class LiveTwinOverviewRepository implements TwinOverviewRepository {
       stats: stats,
       sceneSummary: sceneSummary,
       pendingTasks: pendingTasks,
+      pastureHeadline: desiredState == ViewState.normal ? pastureHeadline : null,
+      pastureDetail: desiredState == ViewState.normal ? pastureDetail : null,
       message: switch (desiredState) {
         ViewState.loading => '加载中',
         ViewState.empty => '暂无孪生数据',

--- a/Mobile/mobile_app/lib/features/twin_overview/data/mock_twin_overview_repository.dart
+++ b/Mobile/mobile_app/lib/features/twin_overview/data/mock_twin_overview_repository.dart
@@ -15,6 +15,10 @@ class MockTwinOverviewRepository implements TwinOverviewRepository {
           desiredState == ViewState.normal ? TwinSeed.sceneSummary : null,
       pendingTasks:
           desiredState == ViewState.normal ? TwinSeed.pendingTasks : const [],
+      pastureHeadline:
+          desiredState == ViewState.normal ? TwinSeed.overviewPastureHeadline : null,
+      pastureDetail:
+          desiredState == ViewState.normal ? TwinSeed.overviewPastureDetail : null,
       message: switch (desiredState) {
         ViewState.loading => '加载中',
         ViewState.empty => '暂无孪生数据',

--- a/Mobile/mobile_app/lib/main.dart
+++ b/Mobile/mobile_app/lib/main.dart
@@ -1,10 +1,19 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/semantics.dart';
 import 'package:flutter/widgets.dart';
 import 'package:smart_livestock_demo/app/app_mode.dart';
 import 'package:smart_livestock_demo/app/demo_app.dart';
+import 'package:smart_livestock_demo/app/url_strategy.dart';
 import 'package:smart_livestock_demo/core/api/api_cache.dart';
+
+SemanticsHandle? _webSemanticsHandle;
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  configureUrlStrategyIfWeb();
+  if (kIsWeb) {
+    _webSemanticsHandle ??= WidgetsBinding.instance.ensureSemantics();
+  }
 
   final appMode = parseAppMode(
     const String.fromEnvironment('APP_MODE', defaultValue: 'mock'),

--- a/Mobile/mobile_app/pubspec.lock
+++ b/Mobile/mobile_app/pubspec.lock
@@ -204,7 +204,7 @@ packages:
     source: sdk
     version: "0.0.0"
   flutter_web_plugins:
-    dependency: transitive
+    dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"

--- a/Mobile/mobile_app/pubspec.yaml
+++ b/Mobile/mobile_app/pubspec.yaml
@@ -9,6 +9,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_web_plugins:
+    sdk: flutter
   fl_chart: ^0.69.0
   flutter_map: ^8.2.2
   flutter_riverpod: ^3.3.1

--- a/Mobile/mobile_app/test/live_devices_repository_test.dart
+++ b/Mobile/mobile_app/test/live_devices_repository_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:smart_livestock_demo/core/data/demo_seed.dart';
+import 'package:smart_livestock_demo/core/models/demo_models.dart';
+import 'package:smart_livestock_demo/features/devices/data/live_devices_repository.dart';
+
+void main() {
+  test('parseDeviceMap 与 DemoSeed 首条 GPS 设备一致', () {
+    final expected = DemoSeed.devices.first;
+    final m = <String, dynamic>{
+      'id': expected.id,
+      'name': expected.name,
+      'type': 'gps',
+      'status': 'online',
+      'boundEarTag': expected.boundEarTag,
+      'batteryPercent': expected.batteryPercent,
+      'signalStrength': expected.signalStrength,
+      'lastSync': expected.lastSync,
+    };
+    final parsed = LiveDevicesRepository.parseDeviceMap(m);
+    expect(parsed, isNotNull);
+    expect(parsed!.id, expected.id);
+    expect(parsed.name, expected.name);
+    expect(parsed.type, DeviceType.gps);
+    expect(parsed.status, DeviceStatus.online);
+    expect(parsed.boundEarTag, expected.boundEarTag);
+  });
+}

--- a/Mobile/mobile_app/test/seed_data_test.dart
+++ b/Mobile/mobile_app/test/seed_data_test.dart
@@ -189,12 +189,14 @@ void main() {
   test('TwinSeed fever baselines have temperature records', () {
     for (final b in TwinSeed.feverBaselines) {
       expect(b.recent72h, isNotEmpty);
+      expect(b.recent72h.length, lessThanOrEqualTo(200));
     }
   });
 
   test('TwinSeed digestive items have motility records', () {
     for (final d in TwinSeed.digestiveItems) {
       expect(d.recent24h, isNotEmpty);
+      expect(d.recent24h.length, lessThanOrEqualTo(200));
     }
   });
 }

--- a/Mobile/mobile_app/test/seed_data_test.dart
+++ b/Mobile/mobile_app/test/seed_data_test.dart
@@ -165,19 +165,19 @@ void main() {
     }
   });
 
-  test('TwinSeed has 30 fever baselines', () {
-    expect(TwinSeed.feverBaselines.length, 30);
+  test('TwinSeed has 50 fever baselines', () {
+    expect(TwinSeed.feverBaselines.length, 50);
   });
 
-  test('TwinSeed fever baselines use livestockId 0001-0030', () {
+  test('TwinSeed fever baselines use livestockId 0001-0050', () {
     final ids = TwinSeed.feverBaselines.map((b) => b.livestockId).toSet();
-    for (var i = 1; i <= 30; i++) {
+    for (var i = 1; i <= 50; i++) {
       expect(ids.contains(i.toString().padLeft(4, '0')), isTrue);
     }
   });
 
-  test('TwinSeed has 30 digestive items', () {
-    expect(TwinSeed.digestiveItems.length, 30);
+  test('TwinSeed has 50 digestive items', () {
+    expect(TwinSeed.digestiveItems.length, 50);
   });
 
   test('TwinSeed has 3 estrus items in estrus', () {

--- a/Mobile/mobile_app/test/twin_overview_pasture_context_test.dart
+++ b/Mobile/mobile_app/test/twin_overview_pasture_context_test.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:smart_livestock_demo/app/demo_app.dart';
+
+void main() {
+  testWidgets('孪生概览展示当前演示牧区与 50 头上下文', (tester) async {
+    await tester.pumpWidget(const DemoApp());
+    await tester.tap(find.byKey(const Key('role-owner')));
+    await tester.tap(find.byKey(const Key('login-submit')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('twin-pasture-context')), findsOneWidget);
+    expect(find.textContaining('50'), findsWidgets);
+    expect(find.textContaining('集团孪生'), findsOneWidget);
+  });
+}

--- a/Mobile/mobile_app/test/twin_series_downsample_test.dart
+++ b/Mobile/mobile_app/test/twin_series_downsample_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:smart_livestock_demo/core/data/twin_series_downsample.dart';
+import 'package:smart_livestock_demo/core/models/twin_models.dart';
+
+void main() {
+  test('hourlyMeanTemperature 合并同一小时多点为均值', () {
+    const id = '0001';
+    final input = [
+      TemperatureRecord(
+        livestockId: id,
+        temperature: 38.0,
+        timestamp: _t(2026, 4, 7, 10, 0),
+      ),
+      TemperatureRecord(
+        livestockId: id,
+        temperature: 40.0,
+        timestamp: _t(2026, 4, 7, 10, 30),
+      ),
+    ];
+    final out = TwinSeriesDownsample.hourlyMeanTemperature(input);
+    expect(out.length, 1);
+    expect(out.single.temperature, 39.0);
+    expect(out.single.timestamp, _t(2026, 4, 7, 10, 0));
+  });
+
+  test('hourlyMeanTemperature 在超过 maxPoints 时均匀截断', () {
+    const id = '0001';
+    final input = <TemperatureRecord>[
+      for (var i = 0; i < 300; i++)
+        TemperatureRecord(
+          livestockId: id,
+          temperature: 38.0,
+          timestamp: DateTime.utc(2026, 4, 1).add(Duration(hours: i)),
+        ),
+    ];
+    final out = TwinSeriesDownsample.hourlyMeanTemperature(input, maxPoints: 50);
+    expect(out.length, lessThanOrEqualTo(50));
+    expect(out.first.livestockId, id);
+  });
+
+  test('hourlyMeanMotility 合并同一小时', () {
+    const id = '0001';
+    final input = [
+      MotilityRecord(
+        livestockId: id,
+        frequency: 1.0,
+        intensity: 0.5,
+        timestamp: _t(2026, 4, 7, 10, 0),
+      ),
+      MotilityRecord(
+        livestockId: id,
+        frequency: 1.4,
+        intensity: 0.7,
+        timestamp: _t(2026, 4, 7, 10, 30),
+      ),
+    ];
+    final out = TwinSeriesDownsample.hourlyMeanMotility(input);
+    expect(out.length, 1);
+    expect(out.single.frequency, 1.2);
+    expect(out.single.intensity, 0.6);
+  });
+
+  test('空序列返回空', () {
+    expect(TwinSeriesDownsample.hourlyMeanTemperature([]), isEmpty);
+    expect(TwinSeriesDownsample.hourlyMeanMotility([]), isEmpty);
+  });
+}
+
+DateTime _t(int y, int m, int d, int h, int min) =>
+    DateTime.utc(y, m, d, h, min);


### PR DESCRIPTION
## 摘要

本 PR 落实孪生演示数据与 Live Mock 对齐、设备种子、概览牧区上下文，以及体温/蠕动序列降采样；并附带 Web 下 Live 模式的可运行性与导航栈小改进。

## 关闭的 Issues

- Closes #3 — Mock/Live 路径对体温与蠕动时序做按小时降采样（`twin_series_downsample.dart` + 仓储层）。
- Closes #5 — Live 孪生时序与 Mock 对齐：后端 `twin_seed.js` 密化小时序列，Flutter Mock/Live 共用降采样策略。
- Closes #6 — 后端设备种子与 `demo_seed` 对齐；`/api/devices` 接入 `ApiCache` 与 `LiveDevicesRepository`。
- Closes #7 — 孪生概览展示「当前演示牧区」及 50 头演示上下文文案与指标口径说明。

## 额外提交（86901b7）

- Web：`flutter_web_plugins` 路径策略、`127.0.0.1` 默认 API 基址、GET 超时。
- 孪生子页从孪生概览进入时使用 `push` 以保留返回栈。
- `TwinSeed` 发热/消化列表扩展为 50 头，与概览文案一致；测试已更新。

## 验证

`cd Mobile/mobile_app && flutter analyze && flutter test` 均已通过。

## 仍开放的 backlog（未在本 PR 范围）

- #4 GPS 轨迹逼真度（可选）
- #8 TimeSeriesGenerator 抽象（P3 refactor）


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new `/api/devices` endpoint and threads device/twin time-series data through caching/downsampling paths, which could affect multiple screens if response shapes or sampling assumptions differ. Also changes web routing/base URL behavior, so regressions would mainly show up in live/web navigation and data rendering.
> 
> **Overview**
> Adds seeded device data to the mock backend and exposes it via a new authenticated `GET /api/devices` route, then wires the mobile app’s live mode to prefetch/cache devices and render them via `LiveDevicesRepository` with a mock fallback.
> 
> Aligns twin demo/live data: backend `twin_seed.js` now generates denser temperature/motility series and includes a `pastureBanner`; the Flutter app adds `TwinSeriesDownsample` (hourly mean + max-point cap) and applies it to both mock seed generation and live repositories, while expanding twin fever/digestive lists to **50** animals and showing the new pasture context card on the twin overview.
> 
> Improves web live experience by switching default web API base URL to `127.0.0.1`, adding request timeouts, enabling path URL strategy via `flutter_web_plugins`, and changing several twin subpage navigations from `go` to `push` to preserve back stack; tests and docs are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86901b7bf5c0054237f457d4a2ec4c24b5e2d851. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->