### PR TITLE
refactor(mobile): TimeSeriesGenerator 抽象 (closes #8)

### DIFF
--- a/Mobile/mobile_app/lib/core/data/generators/estrus_score_generator.dart
+++ b/Mobile/mobile_app/lib/core/data/generators/estrus_score_generator.dart
@@ -1,12 +1,8 @@
-import 'dart:math';
-
+import 'package:smart_livestock_demo/core/data/generators/time_series_generator.dart';
 import 'package:smart_livestock_demo/core/models/twin_models.dart';
 
-class EstrusScoreGenerator {
-  EstrusScoreGenerator({this.seed = 42});
-
-  final int seed;
-  final Map<String, List<EstrusTrendPoint>> _cache = {};
+class EstrusScoreGenerator extends TimeSeriesGenerator<EstrusTrendPoint> {
+  EstrusScoreGenerator({super.seed});
 
   List<EstrusTrendPoint> generate({
     required String livestockId,
@@ -15,7 +11,7 @@ class EstrusScoreGenerator {
     required DateTime start,
     required DateTime end,
   }) {
-    return _cache.putIfAbsent(livestockId, () => _doGenerate(
+    return memoized(livestockId, () => _doGenerate(
           livestockId: livestockId,
           inEstrus: inEstrus,
           cycleDay: cycleDay,
@@ -31,7 +27,7 @@ class EstrusScoreGenerator {
     required DateTime start,
     required DateTime end,
   }) {
-    final rng = Random(seed + livestockId.hashCode);
+    final rng = rngForEntity(livestockId);
     final points = <EstrusTrendPoint>[];
 
     var t = start;

--- a/Mobile/mobile_app/lib/core/data/generators/gps_trajectory_generator.dart
+++ b/Mobile/mobile_app/lib/core/data/generators/gps_trajectory_generator.dart
@@ -1,13 +1,11 @@
 import 'dart:math';
 
 import 'package:latlong2/latlong.dart';
+import 'package:smart_livestock_demo/core/data/generators/time_series_generator.dart';
 import 'package:smart_livestock_demo/core/models/demo_models.dart';
 
-class GpsTrajectoryGenerator {
-  GpsTrajectoryGenerator({this.seed = 42});
-
-  final int seed;
-  final Map<String, List<GeoPoint>> _cache = {};
+class GpsTrajectoryGenerator extends TimeSeriesGenerator<GeoPoint> {
+  GpsTrajectoryGenerator({super.seed});
 
   static String _cacheKey(
     String earTag,
@@ -28,7 +26,7 @@ class GpsTrajectoryGenerator {
     required DateTime end,
   }) {
     final key = _cacheKey(earTag, fenceBoundary, start, end);
-    return _cache.putIfAbsent(key, () => _doGenerate(
+    return memoized(key, () => _doGenerate(
           earTag: earTag,
           fenceBoundary: fenceBoundary,
           start: start,
@@ -42,7 +40,7 @@ class GpsTrajectoryGenerator {
     required DateTime start,
     required DateTime end,
   }) {
-    final rng = Random(seed + earTag.hashCode);
+    final rng = rngForEntity(earTag);
     final points = <GeoPoint>[];
 
     final lats = fenceBoundary.map((p) => p.latitude).toList();

--- a/Mobile/mobile_app/lib/core/data/generators/motility_generator.dart
+++ b/Mobile/mobile_app/lib/core/data/generators/motility_generator.dart
@@ -1,12 +1,8 @@
-import 'dart:math';
-
+import 'package:smart_livestock_demo/core/data/generators/time_series_generator.dart';
 import 'package:smart_livestock_demo/core/models/twin_models.dart';
 
-class MotilityGenerator {
-  MotilityGenerator({this.seed = 42});
-
-  final int seed;
-  final Map<String, List<MotilityRecord>> _cache = {};
+class MotilityGenerator extends TimeSeriesGenerator<MotilityRecord> {
+  MotilityGenerator({super.seed});
 
   List<MotilityRecord> generate({
     required String livestockId,
@@ -15,7 +11,7 @@ class MotilityGenerator {
     required DateTime end,
   }) {
     final key = '${livestockId}_$healthLevel';
-    return _cache.putIfAbsent(key, () => _doGenerate(
+    return memoized(key, () => _doGenerate(
           livestockId: livestockId,
           healthLevel: healthLevel,
           start: start,
@@ -29,7 +25,7 @@ class MotilityGenerator {
     required DateTime start,
     required DateTime end,
   }) {
-    final rng = Random(seed + livestockId.hashCode);
+    final rng = rngForEntity(livestockId);
     final records = <MotilityRecord>[];
 
     var t = start;

--- a/Mobile/mobile_app/lib/core/data/generators/temperature_generator.dart
+++ b/Mobile/mobile_app/lib/core/data/generators/temperature_generator.dart
@@ -1,5 +1,4 @@
-import 'dart:math';
-
+import 'package:smart_livestock_demo/core/data/generators/time_series_generator.dart';
 import 'package:smart_livestock_demo/core/models/twin_models.dart';
 
 class AbnormalTempEvent {
@@ -14,11 +13,8 @@ class AbnormalTempEvent {
   final int durationHours;
 }
 
-class TemperatureGenerator {
-  TemperatureGenerator({this.seed = 42});
-
-  final int seed;
-  final Map<String, List<TemperatureRecord>> _cache = {};
+class TemperatureGenerator extends TimeSeriesGenerator<TemperatureRecord> {
+  TemperatureGenerator({super.seed});
 
   List<TemperatureRecord> generate({
     required String livestockId,
@@ -27,7 +23,7 @@ class TemperatureGenerator {
     required DateTime end,
     List<AbnormalTempEvent> abnormalEvents = const [],
   }) {
-    return _cache.putIfAbsent(livestockId, () => _doGenerate(
+    return memoized(livestockId, () => _doGenerate(
           livestockId: livestockId,
           baselineTemp: baselineTemp,
           start: start,
@@ -43,7 +39,7 @@ class TemperatureGenerator {
     required DateTime end,
     required List<AbnormalTempEvent> abnormalEvents,
   }) {
-    final rng = Random(seed + livestockId.hashCode);
+    final rng = rngForEntity(livestockId);
     final records = <TemperatureRecord>[];
 
     var t = start;

--- a/Mobile/mobile_app/lib/core/data/generators/time_series_generator.dart
+++ b/Mobile/mobile_app/lib/core/data/generators/time_series_generator.dart
@@ -1,0 +1,13 @@
+import 'dart:math';
+
+abstract class TimeSeriesGenerator<T> {
+  TimeSeriesGenerator({this.seed = 42});
+
+  final int seed;
+  final Map<String, List<T>> _cache = {};
+
+  Random rngForEntity(String entityId) => Random(seed + entityId.hashCode);
+
+  List<T> memoized(String key, List<T> Function() compute) =>
+      _cache.putIfAbsent(key, compute);
+}


### PR DESCRIPTION
## 摘要
实现 [Issue #8](https://github.com/aime4eve/smart-livestock/issues/8)：为演示用时间序列生成器抽取统一基类。

## 变更
- 新增 `TimeSeriesGenerator<T>`（`seed`、`rngForEntity`、`memoized` 缓存入口）。
- `TemperatureGenerator`、`MotilityGenerator`、`EstrusScoreGenerator`、`GpsTrajectoryGenerator` 继承基类；各 `generate` 签名与生成逻辑保持不变。

## 验证
- `cd Mobile/mobile_app && flutter analyze` — 无问题
- `flutter test` — 全部通过

Closes #8

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes RNG and memoization logic; main risk is unintended changes to caching/determinism if keys or seeding behavior differ from the previous per-generator implementations.
> 
> **Overview**
> Extracts a new generic `TimeSeriesGenerator<T>` that owns the `seed`, per-entity RNG creation (`rngForEntity`), and a shared memoization cache (`memoized`).
> 
> Refactors `TemperatureGenerator`, `MotilityGenerator`, `EstrusScoreGenerator`, and `GpsTrajectoryGenerator` to extend this base, removing duplicated `seed`/`Random`/cache fields and routing `generate()` through `memoized()` while keeping generation logic and public method signatures the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09dd63df130781c264aee4ec58190d8361c7d233. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->