### PR TITLE
fix(Mobile): Live 围栏地图与 ApiCache、mock API 围栏 CRUD 及越界判定

### DIFF
--- a/Mobile/backend/data/fenceStore.js
+++ b/Mobile/backend/data/fenceStore.js
@@ -1,0 +1,70 @@
+const { fences: seedFences } = require('./seed');
+
+let fences = seedFences.map((f) => ({ ...f }));
+let nextId = fences.length + 1;
+
+function getAll() {
+  return fences;
+}
+
+function findById(id) {
+  return fences.find((f) => f.id === id);
+}
+
+function createFence(body) {
+  const { name, type = 'polygon', coordinates = [], alarmEnabled = true } = body || {};
+  if (!name) {
+    return { error: 'name_required' };
+  }
+  const fence = {
+    id: `fence_${String(nextId++).padStart(3, '0')}`,
+    name,
+    type,
+    status: 'active',
+    alarmEnabled,
+    coordinates,
+  };
+  fences.push(fence);
+  return { fence };
+}
+
+function updateFence(id, body) {
+  const fence = findById(id);
+  if (!fence) {
+    return { error: 'not_found' };
+  }
+  const { name, type, coordinates, alarmEnabled, status } = body || {};
+  if (name !== undefined) fence.name = name;
+  if (type !== undefined) fence.type = type;
+  if (coordinates !== undefined) fence.coordinates = coordinates;
+  if (alarmEnabled !== undefined) fence.alarmEnabled = alarmEnabled;
+  if (status !== undefined) fence.status = status;
+  return { fence };
+}
+
+function removeFence(id) {
+  const idx = fences.findIndex((f) => f.id === id);
+  if (idx === -1) {
+    return { error: 'not_found' };
+  }
+  const [removed] = fences.splice(idx, 1);
+  return { removed };
+}
+
+function sliceForPage(page, pageSize) {
+  const p = Math.max(1, parseInt(page, 10) || 1);
+  const ps = Math.max(1, parseInt(pageSize, 10) || 20);
+  const total = fences.length;
+  const start = (p - 1) * ps;
+  const items = fences.slice(start, start + ps);
+  return { items, page: p, pageSize: ps, total };
+}
+
+module.exports = {
+  getAll,
+  findById,
+  createFence,
+  updateFence,
+  removeFence,
+  sliceForPage,
+};

--- a/Mobile/backend/package.json
+++ b/Mobile/backend/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "dev": "node --watch server.js"
+    "dev": "node --watch server.js",
+    "test": "node test/geo.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/Mobile/backend/routes/fences.js
+++ b/Mobile/backend/routes/fences.js
@@ -1,95 +1,58 @@
 const { Router } = require('express');
 const { authMiddleware, requirePermission } = require('../middleware/auth');
-const { fences: seedFences } = require('../data/seed');
+const fenceStore = require('../data/fenceStore');
 
 const router = Router();
 
-// In-memory fences
-let fences = seedFences.map((f) => ({ ...f }));
-let nextId = fences.length + 1;
-
-/**
- * GET /api/fences
- */
 router.get(
   '/',
   authMiddleware,
   requirePermission('fence:view'),
   (req, res) => {
     const { page = '1', pageSize = '20' } = req.query;
-    const p = Math.max(1, parseInt(page, 10) || 1);
-    const ps = Math.max(1, parseInt(pageSize, 10) || 20);
-    const total = fences.length;
-    const start = (p - 1) * ps;
-    const items = fences.slice(start, start + ps);
-
-    res.ok({ items, page: p, pageSize: ps, total });
-  }
+    res.ok(fenceStore.sliceForPage(page, pageSize));
+  },
 );
 
-/**
- * POST /api/fences
- */
 router.post(
   '/',
   authMiddleware,
   requirePermission('fence:manage'),
   (req, res) => {
-    const { name, type = 'polygon', coordinates = [], alarmEnabled = true } = req.body || {};
-    if (!name) {
+    const result = fenceStore.createFence(req.body || {});
+    if (result.error === 'name_required') {
       return res.fail(422, 'VALIDATION_ERROR', 'name 为必填项');
     }
-    const fence = {
-      id: `fence_${String(nextId++).padStart(3, '0')}`,
-      name,
-      type,
-      status: 'active',
-      alarmEnabled,
-      coordinates,
-    };
-    fences.push(fence);
-    res.ok(fence);
-  }
+    res.ok(result.fence);
+  },
 );
 
-/**
- * PUT /api/fences/:id
- */
 router.put(
   '/:id',
   authMiddleware,
   requirePermission('fence:manage'),
   (req, res) => {
     const { id } = req.params;
-    const fence = fences.find((f) => f.id === id);
-    if (!fence) {
+    const result = fenceStore.updateFence(id, req.body || {});
+    if (result.error === 'not_found') {
       return res.fail(404, 'RESOURCE_NOT_FOUND', '围栏不存在');
     }
-    const { name, type, coordinates, alarmEnabled } = req.body || {};
-    if (name !== undefined) fence.name = name;
-    if (type !== undefined) fence.type = type;
-    if (coordinates !== undefined) fence.coordinates = coordinates;
-    if (alarmEnabled !== undefined) fence.alarmEnabled = alarmEnabled;
-    res.ok(fence);
-  }
+    res.ok(result.fence);
+  },
 );
 
-/**
- * DELETE /api/fences/:id
- */
 router.delete(
   '/:id',
   authMiddleware,
   requirePermission('fence:manage'),
   (req, res) => {
     const { id } = req.params;
-    const idx = fences.findIndex((f) => f.id === id);
-    if (idx === -1) {
+    const result = fenceStore.removeFence(id);
+    if (result.error === 'not_found') {
       return res.fail(404, 'RESOURCE_NOT_FOUND', '围栏不存在');
     }
-    const [removed] = fences.splice(idx, 1);
-    res.ok(removed);
-  }
+    res.ok(result.removed);
+  },
 );
 
 module.exports = router;

--- a/Mobile/backend/routes/map.js
+++ b/Mobile/backend/routes/map.js
@@ -1,6 +1,8 @@
 const { Router } = require('express');
 const { authMiddleware, requirePermission } = require('../middleware/auth');
-const { animals, fences } = require('../data/seed');
+const { animals } = require('../data/seed');
+const fenceStore = require('../data/fenceStore');
+const { boundaryStatusForPoint } = require('../utils/geo');
 
 const router = Router();
 
@@ -23,13 +25,26 @@ router.get(
 
     const points = generateTrajectory(selected, since, now);
 
+    const fenceList = fenceStore.getAll();
+    const animalsOut = animals.map((a) => {
+      const boundaryStatus = boundaryStatusForPoint(fenceList, a.lng, a.lat);
+      return {
+        id: a.id,
+        earTag: a.earTag,
+        lat: a.lat,
+        lng: a.lng,
+        fenceId: a.fenceId,
+        boundaryStatus,
+      };
+    });
+
     res.ok({
-      animals: animals.map((a) => ({ id: a.id, earTag: a.earTag, lat: a.lat, lng: a.lng })),
+      animals: animalsOut,
       selectedAnimalId: selected.id,
       selectedRange: range,
       summaryText: `${selected.earTag} · ${range}`,
       points,
-      fences,
+      fences: fenceList,
       fallbackList: animals.slice(0, 5).map((a) => ({ label: `${a.earTag} · 最近点` })),
     });
   },

--- a/Mobile/backend/test/geo.test.js
+++ b/Mobile/backend/test/geo.test.js
@@ -1,0 +1,32 @@
+const assert = require('assert');
+const { pointInRing, boundaryStatusForPoint } = require('../utils/geo');
+const { fences: seedFences } = require('../data/seed');
+
+const pastureA = seedFences.find((f) => f.id === 'fence_pasture_a');
+
+assert.ok(pastureA, 'seed has fence_pasture_a');
+
+const insideLng = 112.942;
+const insideLat = 28.232;
+assert.strictEqual(
+  pointInRing(insideLng, insideLat, pastureA.coordinates),
+  true,
+  'point inside pasture A',
+);
+
+const outsideLng = 112.5;
+const outsideLat = 28.0;
+assert.strictEqual(
+  pointInRing(outsideLng, outsideLat, pastureA.coordinates),
+  false,
+  'point outside pasture A',
+);
+
+const list = require('../data/fenceStore').getAll();
+const st = boundaryStatusForPoint(list, insideLng, insideLat);
+assert.strictEqual(st, 'inside');
+
+const st2 = boundaryStatusForPoint(list, outsideLng, outsideLat);
+assert.strictEqual(st2, 'outside');
+
+console.log('geo.test.js OK');

--- a/Mobile/backend/utils/geo.js
+++ b/Mobile/backend/utils/geo.js
@@ -1,0 +1,46 @@
+function pointInRing(lng, lat, ring) {
+  if (!ring || ring.length < 3) {
+    return false;
+  }
+  const x = lng;
+  const y = lat;
+  let inside = false;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const xi = ring[i][0];
+    const yi = ring[i][1];
+    const xj = ring[j][0];
+    const yj = ring[j][1];
+    const denom = yj - yi;
+    const intersect =
+      yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / (denom === 0 ? 1e-12 : denom) + xi;
+    if (intersect) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+function pointInAnyFence(fences, lng, lat) {
+  if (!fences || fences.length === 0) {
+    return false;
+  }
+  for (const f of fences) {
+    if (f.status && f.status !== 'active') {
+      continue;
+    }
+    const coords = f.coordinates;
+    if (!coords || coords.length < 3) {
+      continue;
+    }
+    if (pointInRing(lng, lat, coords)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function boundaryStatusForPoint(fences, lng, lat) {
+  return pointInAnyFence(fences, lng, lat) ? 'inside' : 'outside';
+}
+
+module.exports = { pointInRing, pointInAnyFence, boundaryStatusForPoint };

--- a/Mobile/mobile_app/lib/core/api/api_cache.dart
+++ b/Mobile/mobile_app/lib/core/api/api_cache.dart
@@ -7,11 +7,18 @@ const String _apiBaseUrlFromEnv = String.fromEnvironment(
   defaultValue: '',
 );
 
-String _resolveApiBaseUrl() {
+String resolveApiBaseUrl() {
   if (_apiBaseUrlFromEnv.isNotEmpty) {
     return _apiBaseUrlFromEnv;
   }
   return kIsWeb ? 'http://127.0.0.1:3001/api' : 'http://localhost:3001/api';
+}
+
+Map<String, String> _headers(String role) {
+  return {
+    'Authorization': 'Bearer mock-token-$role',
+    'Content-Type': 'application/json',
+  };
 }
 
 class ApiCache {
@@ -54,11 +61,7 @@ class ApiCache {
   List<Map<String, dynamic>> get devices => _devices;
 
   Future<void> init(String role) async {
-    final token = 'mock-token-$role';
-    final headers = {
-      'Authorization': 'Bearer $token',
-      'Content-Type': 'application/json',
-    };
+    final headers = _headers(role);
 
     try {
       final results = await Future.wait([
@@ -157,7 +160,7 @@ class ApiCache {
   ) async {
     final response = await http
         .get(
-          Uri.parse('${_resolveApiBaseUrl()}$path'),
+          Uri.parse('${resolveApiBaseUrl()}$path'),
           headers: headers,
         )
         .timeout(const Duration(seconds: 20));
@@ -168,5 +171,75 @@ class ApiCache {
       }
     }
     return null;
+  }
+
+  Future<void> refreshFencesAndMap(String role) async {
+    final headers = _headers(role);
+    final fencesData = await _get('/fences?pageSize=100', headers);
+    if (fencesData != null) {
+      _fences =
+          List<Map<String, dynamic>>.from(fencesData['items'] ?? []);
+    }
+    final mapData = await _get(
+      '/map/trajectories?animalId=animal_001&range=24h',
+      headers,
+    );
+    if (mapData != null) {
+      _animals =
+          List<Map<String, dynamic>>.from(mapData['animals'] ?? []);
+      _mapTrajectoryPoints =
+          List<Map<String, dynamic>>.from(mapData['points'] ?? []);
+    }
+  }
+
+  Future<bool> deleteFenceRemote(String role, String id) async {
+    final response = await http
+        .delete(
+          Uri.parse('${resolveApiBaseUrl()}/fences/$id'),
+          headers: _headers(role),
+        )
+        .timeout(const Duration(seconds: 20));
+    if (response.statusCode == 200) {
+      final body = jsonDecode(response.body) as Map<String, dynamic>;
+      return body['code'] == 'OK';
+    }
+    return false;
+  }
+
+  Future<bool> createFenceRemote(
+    String role,
+    Map<String, dynamic> body,
+  ) async {
+    final response = await http
+        .post(
+          Uri.parse('${resolveApiBaseUrl()}/fences'),
+          headers: _headers(role),
+          body: jsonEncode(body),
+        )
+        .timeout(const Duration(seconds: 20));
+    if (response.statusCode == 200) {
+      final decoded = jsonDecode(response.body) as Map<String, dynamic>;
+      return decoded['code'] == 'OK';
+    }
+    return false;
+  }
+
+  Future<bool> updateFenceRemote(
+    String role,
+    String id,
+    Map<String, dynamic> body,
+  ) async {
+    final response = await http
+        .put(
+          Uri.parse('${resolveApiBaseUrl()}/fences/$id'),
+          headers: _headers(role),
+          body: jsonEncode(body),
+        )
+        .timeout(const Duration(seconds: 20));
+    if (response.statusCode == 200) {
+      final decoded = jsonDecode(response.body) as Map<String, dynamic>;
+      return decoded['code'] == 'OK';
+    }
+    return false;
   }
 }

--- a/Mobile/mobile_app/lib/core/api/api_role.dart
+++ b/Mobile/mobile_app/lib/core/api/api_role.dart
@@ -1,0 +1,4 @@
+const String apiRoleFromEnvironment = String.fromEnvironment(
+  'API_ROLE',
+  defaultValue: 'owner',
+);

--- a/Mobile/mobile_app/lib/features/fence/data/fence_dto.dart
+++ b/Mobile/mobile_app/lib/features/fence/data/fence_dto.dart
@@ -1,0 +1,83 @@
+import 'package:latlong2/latlong.dart';
+import 'package:smart_livestock_demo/core/data/demo_seed.dart';
+import 'package:smart_livestock_demo/features/fence/domain/fence_item.dart';
+
+FenceType fenceTypeFromApiString(String? raw) {
+  return switch (raw) {
+    'rectangle' => FenceType.rectangle,
+    'circle' => FenceType.circle,
+    _ => FenceType.polygon,
+  };
+}
+
+List<LatLng> coordinatesToLatLngPoints(List<dynamic>? raw) {
+  if (raw == null) {
+    return [];
+  }
+  final out = <LatLng>[];
+  for (final c in raw) {
+    if (c is List && c.length >= 2) {
+      final lng = (c[0] as num).toDouble();
+      final lat = (c[1] as num).toDouble();
+      out.add(LatLng(lat, lng));
+    }
+  }
+  return out;
+}
+
+FenceItem fenceItemFromJson(
+  Map<String, dynamic> raw,
+  int colorIndex,
+  int livestockCount,
+) {
+  final id = raw['id'] as String? ?? '';
+  final name = raw['name'] as String? ?? '未命名';
+  final type = fenceTypeFromApiString(raw['type'] as String?);
+  final alarmEnabled = raw['alarmEnabled'] as bool? ?? true;
+  final status = raw['status'] as String? ?? 'active';
+  final active = status == 'active';
+  var points = coordinatesToLatLngPoints(raw['coordinates'] as List<dynamic>?);
+  if (points.length < 3) {
+    points = FenceItem.defaultPointsForType(type, DemoSeed.mapCenter);
+  }
+  const colors = FenceItem.defaultColors;
+  final colorValue = colors[colorIndex % colors.length];
+  return FenceItem(
+    id: id,
+    name: name,
+    type: type,
+    alarmEnabled: alarmEnabled,
+    active: active,
+    areaHectares: 0,
+    livestockCount: livestockCount,
+    colorValue: colorValue,
+    points: points,
+  );
+}
+
+List<FenceItem> fenceItemsFromApiMaps(
+  List<Map<String, dynamic>> rows,
+  Map<String, int> livestockByFenceId,
+) {
+  final out = <FenceItem>[];
+  for (var i = 0; i < rows.length; i++) {
+    final r = rows[i];
+    final id = r['id'] as String? ?? '';
+    final count = livestockByFenceId[id] ?? 0;
+    out.add(fenceItemFromJson(r, i, count));
+  }
+  return out;
+}
+
+Map<String, int> livestockCountsByFenceId(
+  List<Map<String, dynamic>> animals,
+) {
+  final map = <String, int>{};
+  for (final a in animals) {
+    final fid = a['fenceId'] as String?;
+    if (fid != null) {
+      map[fid] = (map[fid] ?? 0) + 1;
+    }
+  }
+  return map;
+}

--- a/Mobile/mobile_app/lib/features/fence/data/live_fence_repository.dart
+++ b/Mobile/mobile_app/lib/features/fence/data/live_fence_repository.dart
@@ -1,3 +1,5 @@
+import 'package:smart_livestock_demo/core/api/api_cache.dart';
+import 'package:smart_livestock_demo/features/fence/data/fence_dto.dart';
 import 'package:smart_livestock_demo/features/fence/data/mock_fence_repository.dart';
 import 'package:smart_livestock_demo/features/fence/domain/fence_item.dart';
 import 'package:smart_livestock_demo/features/fence/domain/fence_repository.dart';
@@ -9,6 +11,18 @@ class LiveFenceRepository implements FenceRepository {
 
   @override
   List<FenceItem> loadAll() {
-    return _fallback.loadAll();
+    final cache = ApiCache.instance;
+    if (!cache.initialized) {
+      return _fallback.loadAll();
+    }
+    final rows = cache.fences;
+    if (rows.isEmpty) {
+      return _fallback.loadAll();
+    }
+    final counts = livestockCountsByFenceId(cache.animals);
+    return fenceItemsFromApiMaps(
+      rows.map((e) => Map<String, dynamic>.from(e)).toList(),
+      counts,
+    );
   }
 }

--- a/Mobile/mobile_app/lib/features/fence/presentation/fence_controller.dart
+++ b/Mobile/mobile_app/lib/features/fence/presentation/fence_controller.dart
@@ -55,6 +55,19 @@ class FenceController extends Notifier<FenceState> {
       viewState: newFences.isEmpty ? ViewState.empty : state.viewState,
     );
   }
+
+  void reloadFromRepository() {
+    final fences = ref.read(fenceRepositoryProvider).loadAll();
+    var selected = state.selectedFenceId;
+    if (selected != null && !fences.any((f) => f.id == selected)) {
+      selected = null;
+    }
+    state = FenceState(
+      fences: fences,
+      selectedFenceId: selected,
+      viewState: fences.isEmpty ? ViewState.empty : ViewState.normal,
+    );
+  }
 }
 
 final fenceControllerProvider =

--- a/Mobile/mobile_app/lib/features/pages/fence_form_page.dart
+++ b/Mobile/mobile_app/lib/features/pages/fence_form_page.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:smart_livestock_demo/app/app_mode.dart';
+import 'package:smart_livestock_demo/core/api/api_cache.dart';
+import 'package:smart_livestock_demo/core/api/api_role.dart';
 import 'package:smart_livestock_demo/core/data/demo_seed.dart';
 import 'package:smart_livestock_demo/core/theme/app_colors.dart';
 import 'package:smart_livestock_demo/core/theme/app_spacing.dart';
@@ -54,9 +57,51 @@ class _FenceFormPageState extends ConsumerState<FenceFormPage> {
   Future<void> _save() async {
     if (!_formKey.currentState!.validate()) return;
     setState(() => _saving = true);
+
+    final appMode = ref.read(appModeProvider);
+    final controller = ref.read(fenceControllerProvider.notifier);
+
+    if (appMode.isLive) {
+      final coords = _coordinatesForSave();
+      final body = <String, dynamic>{
+        'name': _nameController.text.trim(),
+        'type': _type.name,
+        'coordinates': coords,
+        'alarmEnabled': _alarmEnabled,
+      };
+      if (_isEdit) {
+        body['status'] = _active ? 'active' : 'inactive';
+      }
+      final ok = _isEdit
+          ? await ApiCache.instance.updateFenceRemote(
+              apiRoleFromEnvironment,
+              widget.fenceId!,
+              body,
+            )
+          : await ApiCache.instance.createFenceRemote(
+              apiRoleFromEnvironment,
+              body,
+            );
+      if (!ok) {
+        if (mounted) {
+          setState(() => _saving = false);
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('保存失败，请稍后重试')),
+          );
+        }
+        return;
+      }
+      await ApiCache.instance.refreshFencesAndMap(apiRoleFromEnvironment);
+      controller.reloadFromRepository();
+      if (mounted) {
+        setState(() => _saving = false);
+        context.pop();
+      }
+      return;
+    }
+
     await Future.delayed(const Duration(milliseconds: 500));
 
-    final controller = ref.read(fenceControllerProvider.notifier);
     if (_isEdit) {
       final fenceState = ref.read(fenceControllerProvider);
       FenceItem? existing;
@@ -91,7 +136,32 @@ class _FenceFormPageState extends ConsumerState<FenceFormPage> {
       ));
     }
 
-    if (mounted) context.pop();
+    if (mounted) {
+      setState(() => _saving = false);
+      context.pop();
+    }
+  }
+
+  List<List<double>> _coordinatesForSave() {
+    final fenceState = ref.read(fenceControllerProvider);
+    if (_isEdit) {
+      FenceItem? existing;
+      for (final f in fenceState.fences) {
+        if (f.id == widget.fenceId) {
+          existing = f;
+          break;
+        }
+      }
+      if (existing != null) {
+        final pts = existing.type == _type
+            ? existing.points
+            : FenceItem.defaultPointsForType(_type, DemoSeed.mapCenter);
+        return pts.map((p) => [p.longitude, p.latitude]).toList();
+      }
+    }
+    return FenceItem.defaultPointsForType(_type, DemoSeed.mapCenter)
+        .map((p) => [p.longitude, p.latitude])
+        .toList();
   }
 
   @override

--- a/Mobile/mobile_app/lib/features/pages/fence_page.dart
+++ b/Mobile/mobile_app/lib/features/pages/fence_page.dart
@@ -5,8 +5,11 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:latlong2/latlong.dart';
+import 'package:smart_livestock_demo/app/app_mode.dart';
 import 'package:smart_livestock_demo/app/app_route.dart';
 import 'package:smart_livestock_demo/app/session/session_controller.dart';
+import 'package:smart_livestock_demo/core/api/api_cache.dart';
+import 'package:smart_livestock_demo/core/api/api_role.dart';
 import 'package:smart_livestock_demo/core/data/demo_seed.dart';
 import 'package:smart_livestock_demo/core/map/map_config.dart';
 import 'package:smart_livestock_demo/core/mock/mock_config.dart';
@@ -38,6 +41,7 @@ class _FencePageState extends ConsumerState<FencePage> {
   @override
   Widget build(BuildContext context) {
     final fenceState = ref.watch(fenceControllerProvider);
+    final appMode = ref.watch(appModeProvider);
     final controller = ref.read(fenceControllerProvider.notifier);
     final role = ref.watch(sessionControllerProvider).role!;
     final canManage = RolePermission.canEditFence(role);
@@ -45,7 +49,13 @@ class _FencePageState extends ConsumerState<FencePage> {
     return Scaffold(
       key: const Key('page-fence'),
       appBar: AppBar(title: const Text(MockConfig.ranchName)),
-      body: _buildBody(context, fenceState, controller, canManage),
+      body: _buildBody(
+        context,
+        fenceState,
+        controller,
+        canManage,
+        appMode,
+      ),
     );
   }
 
@@ -54,6 +64,7 @@ class _FencePageState extends ConsumerState<FencePage> {
     FenceState fenceState,
     FenceController controller,
     bool canManage,
+    AppMode appMode,
   ) {
     switch (fenceState.viewState) {
       case ViewState.loading:
@@ -69,7 +80,13 @@ class _FencePageState extends ConsumerState<FencePage> {
         );
       case ViewState.normal:
       case ViewState.empty:
-        return _buildMapWithDrawer(context, fenceState, controller, canManage);
+        return _buildMapWithDrawer(
+          context,
+          fenceState,
+          controller,
+          canManage,
+          appMode,
+        );
     }
   }
 
@@ -78,6 +95,7 @@ class _FencePageState extends ConsumerState<FencePage> {
     FenceState fenceState,
     FenceController controller,
     bool canManage,
+    AppMode appMode,
   ) {
     const panelAnimDuration = Duration(milliseconds: 280);
     const panelCurve = Curves.easeOutCubic;
@@ -116,22 +134,26 @@ class _FencePageState extends ConsumerState<FencePage> {
                       );
                     }).toList(),
                   ),
-                  MarkerLayer(
-                    markers: [
-                      for (int i = 0;
-                          i < DemoSeed.livestockLocations.length;
-                          i++)
-                        Marker(
-                          point: DemoSeed.livestockLocations[i].toLatLng(),
-                          width: 56,
-                          height: 56,
-                          child: _MapMarker(
-                            label: DemoSeed
-                                .earTags[i < DemoSeed.earTags.length ? i : 0],
-                            isAlert: i == 0,
-                          ),
+                  if (appMode.isLive &&
+                      ApiCache.instance.initialized &&
+                      ApiCache.instance.mapTrajectoryPoints.isNotEmpty)
+                    PolylineLayer(
+                      polylines: [
+                        Polyline(
+                          points: [
+                            for (final p in ApiCache.instance.mapTrajectoryPoints)
+                              LatLng(
+                                (p['lat'] as num).toDouble(),
+                                (p['lng'] as num).toDouble(),
+                              ),
+                          ],
+                          color: AppColors.primary,
+                          strokeWidth: 3,
                         ),
-                    ],
+                      ],
+                    ),
+                  MarkerLayer(
+                    markers: _buildLivestockMarkers(appMode),
                   ),
                 ],
               ),
@@ -171,8 +193,15 @@ class _FencePageState extends ConsumerState<FencePage> {
                             if (canManage)
                               IconButton(
                                 key: const Key('fence-add'),
-                                onPressed: () =>
-                                    context.push(AppRoute.fenceForm.path),
+                                onPressed: () => context
+                                    .push(AppRoute.fenceForm.path)
+                                    .then((_) {
+                                  if (appMode.isLive) {
+                                    ref
+                                        .read(fenceControllerProvider.notifier)
+                                        .reloadFromRepository();
+                                  }
+                                }),
                                 icon: const Icon(Icons.add_circle_outline),
                                 tooltip: '新建围栏',
                               ),
@@ -209,11 +238,23 @@ class _FencePageState extends ConsumerState<FencePage> {
                                 );
                                 setState(() => _panelOpen = false);
                               },
-                              onEdit: () => context.push(
+                              onEdit: () => context
+                                  .push(
                                 '${AppRoute.fenceForm.path}?id=${fence.id}',
-                              ),
+                              )
+                                  .then((_) {
+                                if (appMode.isLive) {
+                                  ref
+                                      .read(fenceControllerProvider.notifier)
+                                      .reloadFromRepository();
+                                }
+                              }),
                               onDelete: () => _showDeleteDialog(
-                                  context, fence, controller),
+                                context,
+                                fence,
+                                controller,
+                                appMode,
+                              ),
                             ),
                       ],
                     ),
@@ -245,6 +286,59 @@ class _FencePageState extends ConsumerState<FencePage> {
     );
   }
 
+  List<Marker> _buildLivestockMarkers(AppMode appMode) {
+    if (appMode.isMock) {
+      return [
+        for (int i = 0; i < DemoSeed.livestockLocations.length; i++)
+          Marker(
+            key: Key('fence-map-marker-$i'),
+            point: DemoSeed.livestockLocations[i].toLatLng(),
+            width: 56,
+            height: 56,
+            child: _MapMarker(
+              label: DemoSeed
+                  .earTags[i < DemoSeed.earTags.length ? i : 0],
+              isAlert: i == 0,
+            ),
+          ),
+      ];
+    }
+    if (!ApiCache.instance.initialized ||
+        ApiCache.instance.animals.isEmpty) {
+      return [
+        for (int i = 0; i < DemoSeed.livestockLocations.length; i++)
+          Marker(
+            key: Key('fence-map-marker-fallback-$i'),
+            point: DemoSeed.livestockLocations[i].toLatLng(),
+            width: 56,
+            height: 56,
+            child: _MapMarker(
+              label: DemoSeed
+                  .earTags[i < DemoSeed.earTags.length ? i : 0],
+              isAlert: i == 0,
+            ),
+          ),
+      ];
+    }
+    final animals = ApiCache.instance.animals;
+    return [
+      for (var i = 0; i < animals.length; i++)
+        Marker(
+          key: Key('fence-map-marker-$i'),
+          point: LatLng(
+            (animals[i]['lat'] as num).toDouble(),
+            (animals[i]['lng'] as num).toDouble(),
+          ),
+          width: 56,
+          height: 56,
+          child: _MapMarker(
+            label: animals[i]['earTag'] as String? ?? '-',
+            isAlert: animals[i]['boundaryStatus'] == 'outside',
+          ),
+        ),
+    ];
+  }
+
   LatLng _fenceCenter(List<LatLng> points) {
     double lat = 0, lng = 0;
     for (final p in points) {
@@ -258,6 +352,7 @@ class _FencePageState extends ConsumerState<FencePage> {
     BuildContext context,
     FenceItem fence,
     FenceController controller,
+    AppMode appMode,
   ) {
     showDialog<void>(
       context: context,
@@ -272,14 +367,41 @@ class _FencePageState extends ConsumerState<FencePage> {
           ),
           TextButton(
             key: const Key('fence-delete-confirm'),
-            onPressed: () {
-              controller.delete(fence.id);
+            onPressed: () async {
               Navigator.of(ctx).pop();
-              ScaffoldMessenger.of(context)
-                ..hideCurrentSnackBar()
-                ..showSnackBar(
-                  SnackBar(content: Text('已删除「${fence.name}」')),
-                );
+              if (appMode.isLive) {
+                final ok = await ApiCache.instance
+                    .deleteFenceRemote(apiRoleFromEnvironment, fence.id);
+                if (!context.mounted) {
+                  return;
+                }
+                if (ok) {
+                  await ApiCache.instance
+                      .refreshFencesAndMap(apiRoleFromEnvironment);
+                  if (!context.mounted) {
+                    return;
+                  }
+                  controller.reloadFromRepository();
+                  ScaffoldMessenger.of(context)
+                    ..hideCurrentSnackBar()
+                    ..showSnackBar(
+                      SnackBar(content: Text('已删除「${fence.name}」')),
+                    );
+                } else {
+                  ScaffoldMessenger.of(context)
+                    ..hideCurrentSnackBar()
+                    ..showSnackBar(
+                      const SnackBar(content: Text('删除失败，请稍后重试')),
+                    );
+                }
+              } else {
+                controller.delete(fence.id);
+                ScaffoldMessenger.of(context)
+                  ..hideCurrentSnackBar()
+                  ..showSnackBar(
+                    SnackBar(content: Text('已删除「${fence.name}」')),
+                  );
+              }
             },
             child: const Text('删除', style: TextStyle(color: AppColors.danger)),
           ),

--- a/Mobile/mobile_app/test/fence_dto_test.dart
+++ b/Mobile/mobile_app/test/fence_dto_test.dart
@@ -1,0 +1,50 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:latlong2/latlong.dart';
+import 'package:smart_livestock_demo/features/fence/data/fence_dto.dart';
+import 'package:smart_livestock_demo/features/fence/domain/fence_item.dart';
+
+void main() {
+  test('coordinatesToLatLngPoints maps lng lat pairs to LatLng', () {
+    final pts = coordinatesToLatLngPoints([
+      [112.94, 28.234],
+      [112.944, 28.2305],
+    ]);
+    expect(pts.length, 2);
+    expect(pts[0], const LatLng(28.234, 112.94));
+    expect(pts[1], const LatLng(28.2305, 112.944));
+  });
+
+  test('livestockCountsByFenceId aggregates fenceId', () {
+    final m = livestockCountsByFenceId([
+      {'fenceId': 'fence_a'},
+      {'fenceId': 'fence_a'},
+      {'fenceId': 'fence_b'},
+    ]);
+    expect(m['fence_a'], 2);
+    expect(m['fence_b'], 1);
+  });
+
+  test('fenceItemFromJson builds FenceItem from API map', () {
+    final item = fenceItemFromJson(
+      {
+        'id': 'fence_pasture_a',
+        'name': '放牧A区',
+        'type': 'polygon',
+        'alarmEnabled': true,
+        'status': 'active',
+        'coordinates': [
+          [112.94, 28.234],
+          [112.944, 28.234],
+          [112.944, 28.2305],
+          [112.94, 28.2305],
+        ],
+      },
+      0,
+      12,
+    );
+    expect(item.id, 'fence_pasture_a');
+    expect(item.livestockCount, 12);
+    expect(item.points.length, 4);
+    expect(item.type, FenceType.polygon);
+  });
+}


### PR DESCRIPTION
## 摘要
- **Live 围栏页**：`APP_MODE=live` 且 `ApiCache` 已初始化时，牲畜标记使用接口返回的 `animals`（`boundaryStatus == outside` 时红色警示），并绘制 `mapTrajectoryPoints` 折线；未初始化或无数据时回退 `DemoSeed`。
- **LiveFenceRepository**：从 `ApiCache.fences` 解析 `FenceItem`（`[lng,lat]` → `LatLng`），并按 `fenceId` 统计头数。
- **围栏 CRUD**：`ApiCache` 增加 `create/update/deleteFenceRemote` 与 `refreshFencesAndMap`；表单与删除在 live 模式下走 HTTP，成功后刷新缓存并 `reloadFromRepository`。
- **后端**：`fenceStore` 统一内存围栏；`map/trajectories` 返回 `boundaryStatus`、`fenceId` 与当前围栏列表；`utils/geo` 射线法判定。
- **测试**：`Mobile/mobile_app/test/fence_dto_test.dart`；`Mobile/backend` 增加 `npm test`（`test/geo.test.js`）。

## 验证
```bash
cd Mobile/backend && npm test
cd Mobile/mobile_app && flutter analyze && flutter test
```

Closes #13
Closes #14

Made with [Cursor](https://cursor.com)