### PR TITLE
feat(mobile): improve mock GPS trajectory realism

### DIFF
--- a/Mobile/mobile_app/lib/core/data/demo_seed.dart
+++ b/Mobile/mobile_app/lib/core/data/demo_seed.dart
@@ -11,6 +11,13 @@ class DemoSeed {
 
   static const List<GeoPoint> trajectoryPoints = [];
 
+  static const List<LatLng> gpsAnchorPoints = [
+    LatLng(28.2336, 112.9435),
+    LatLng(28.2312, 112.9409),
+    LatLng(28.2268, 112.9342),
+    LatLng(28.2254, 112.9357),
+  ];
+
   static const List<FencePolygon> fencePolygons = [
     FencePolygon(
       id: 'fence_pasture_a',
@@ -67,6 +74,15 @@ class DemoSeed {
   ];
 
   static final List<LivestockInfo> livestock = _generateLivestock();
+
+  static List<LatLng> fencePointsById(String fenceId) {
+    for (final fence in fencePolygons) {
+      if (fence.id == fenceId) {
+        return fence.points;
+      }
+    }
+    return const [];
+  }
 
   static List<String> get earTags =>
       livestock.map((l) => l.earTag).toList();

--- a/Mobile/mobile_app/lib/core/data/generators/gps_trajectory_generator.dart
+++ b/Mobile/mobile_app/lib/core/data/generators/gps_trajectory_generator.dart
@@ -7,34 +7,86 @@ import 'package:smart_livestock_demo/core/models/demo_models.dart';
 class GpsTrajectoryGenerator extends TimeSeriesGenerator<GeoPoint> {
   GpsTrajectoryGenerator({super.seed});
 
+  static int _fingerprintPoints(List<LatLng>? points) {
+    if (points == null || points.isEmpty) {
+      return 0;
+    }
+    return Object.hashAll(
+      points.map((p) => Object.hash(p.latitude, p.longitude)),
+    );
+  }
+
   static String _cacheKey(
     String earTag,
     List<LatLng> fenceBoundary,
+    List<LatLng>? restFenceBoundary,
+    List<LatLng>? anchorPoints,
     DateTime start,
     DateTime end,
   ) {
-    final fenceFp = Object.hashAll(
-      fenceBoundary.map((p) => Object.hash(p.latitude, p.longitude)),
-    );
-    return '$earTag|$fenceFp|${start.millisecondsSinceEpoch}|${end.millisecondsSinceEpoch}';
+    final fenceFp = _fingerprintPoints(fenceBoundary);
+    final restFenceFp = _fingerprintPoints(restFenceBoundary);
+    final anchorFp = _fingerprintPoints(anchorPoints);
+    return '$earTag|$fenceFp|$restFenceFp|$anchorFp|${start.millisecondsSinceEpoch}|${end.millisecondsSinceEpoch}';
   }
 
   List<GeoPoint> generate({
     required String earTag,
     required List<LatLng> fenceBoundary,
+    List<LatLng>? restFenceBoundary,
+    List<LatLng>? anchorPoints,
     required DateTime start,
     required DateTime end,
   }) {
-    final key = _cacheKey(earTag, fenceBoundary, start, end);
+    final key = _cacheKey(
+      earTag,
+      fenceBoundary,
+      restFenceBoundary,
+      anchorPoints,
+      start,
+      end,
+    );
     return memoized(key, () => _doGenerate(
           earTag: earTag,
           fenceBoundary: fenceBoundary,
+          restFenceBoundary: restFenceBoundary,
+          anchorPoints: anchorPoints,
           start: start,
           end: end,
         ));
   }
 
   List<GeoPoint> _doGenerate({
+    required String earTag,
+    required List<LatLng> fenceBoundary,
+    List<LatLng>? restFenceBoundary,
+    List<LatLng>? anchorPoints,
+    required DateTime start,
+    required DateTime end,
+  }) {
+    final hasRestFence =
+        restFenceBoundary != null && restFenceBoundary.isNotEmpty;
+    final hasAnchors = anchorPoints != null && anchorPoints.isNotEmpty;
+    final enhancedMode = hasRestFence || hasAnchors;
+    if (!enhancedMode) {
+      return _doGenerateLegacy(
+        earTag: earTag,
+        fenceBoundary: fenceBoundary,
+        start: start,
+        end: end,
+      );
+    }
+    return _doGenerateEnhanced(
+      earTag: earTag,
+      fenceBoundary: fenceBoundary,
+      restFenceBoundary: restFenceBoundary ?? fenceBoundary,
+      anchorPoints: anchorPoints ?? const [],
+      start: start,
+      end: end,
+    );
+  }
+
+  List<GeoPoint> _doGenerateLegacy({
     required String earTag,
     required List<LatLng> fenceBoundary,
     required DateTime start,
@@ -80,4 +132,123 @@ class GpsTrajectoryGenerator extends TimeSeriesGenerator<GeoPoint> {
 
     return points;
   }
+
+  List<GeoPoint> _doGenerateEnhanced({
+    required String earTag,
+    required List<LatLng> fenceBoundary,
+    required List<LatLng> restFenceBoundary,
+    required List<LatLng> anchorPoints,
+    required DateTime start,
+    required DateTime end,
+  }) {
+    final rng = rngForEntity(earTag);
+    final points = <GeoPoint>[];
+    final mainBounds = _boundsFromPolygon(fenceBoundary);
+    final restBounds = _boundsFromPolygon(restFenceBoundary);
+    final nearBoundaryMode = earTag.hashCode.abs() % 23 == 0;
+
+    var currentLat =
+        mainBounds.centerLat + (rng.nextDouble() - 0.5) * mainBounds.latSpan * 0.3;
+    var currentLng =
+        mainBounds.centerLng + (rng.nextDouble() - 0.5) * mainBounds.lngSpan * 0.3;
+
+    var t = start;
+    var wasNight = false;
+    while (t.isBefore(end)) {
+      final hour = t.hour;
+      final isNight = hour < 6 || hour >= 18;
+      final activeBounds = isNight ? restBounds : mainBounds;
+
+      if (isNight && !wasNight) {
+        currentLat = restBounds.centerLat + (rng.nextDouble() - 0.5) * 0.0002;
+        currentLng = restBounds.centerLng + (rng.nextDouble() - 0.5) * 0.0002;
+      }
+
+      if (!isNight && anchorPoints.isNotEmpty) {
+        final idx =
+            (earTag.hashCode.abs() + _dayOfYear(t) + hour) % anchorPoints.length;
+        final target = anchorPoints[idx];
+        final bias = hour % 3 == 0 ? 0.32 : 0.14;
+        currentLat += (target.latitude - currentLat) * bias;
+        currentLng += (target.longitude - currentLng) * bias;
+      }
+
+      final step = isNight ? 0.00005 : 0.00028;
+      currentLat += (rng.nextDouble() - 0.5) * step * 2;
+      currentLng += (rng.nextDouble() - 0.5) * step * 2;
+
+      if (!isNight && nearBoundaryMode && hour % 7 == 0) {
+        final side = rng.nextInt(4);
+        switch (side) {
+          case 0:
+            currentLat = mainBounds.maxLat - 0.00012;
+            break;
+          case 1:
+            currentLat = mainBounds.minLat + 0.00012;
+            break;
+          case 2:
+            currentLng = mainBounds.maxLng - 0.00012;
+            break;
+          case 3:
+            currentLng = mainBounds.minLng + 0.00012;
+            break;
+        }
+      }
+
+      const margin = 0.0001;
+      currentLat = currentLat.clamp(
+        activeBounds.minLat + margin,
+        activeBounds.maxLat - margin,
+      );
+      currentLng = currentLng.clamp(
+        activeBounds.minLng + margin,
+        activeBounds.maxLng - margin,
+      );
+
+      points.add(GeoPoint(
+        lat: double.parse(currentLat.toStringAsFixed(4)),
+        lng: double.parse(currentLng.toStringAsFixed(4)),
+        timestamp: t.toIso8601String(),
+      ));
+
+      wasNight = isNight;
+      t = t.add(const Duration(hours: 1));
+    }
+    return points;
+  }
+
+  int _dayOfYear(DateTime dt) {
+    final firstDay = DateTime(dt.year, 1, 1);
+    return dt.difference(firstDay).inDays + 1;
+  }
+
+  _Bounds _boundsFromPolygon(List<LatLng> polygon) {
+    final lats = polygon.map((p) => p.latitude).toList();
+    final lngs = polygon.map((p) => p.longitude).toList();
+    return _Bounds(
+      minLat: lats.reduce(min),
+      maxLat: lats.reduce(max),
+      minLng: lngs.reduce(min),
+      maxLng: lngs.reduce(max),
+    );
+  }
+}
+
+class _Bounds {
+  const _Bounds({
+    required this.minLat,
+    required this.maxLat,
+    required this.minLng,
+    required this.maxLng,
+  });
+
+  final double minLat;
+  final double maxLat;
+  final double minLng;
+  final double maxLng;
+
+  double get centerLat => (minLat + maxLat) / 2;
+  double get centerLng => (minLng + maxLng) / 2;
+  double get latSpan => max(maxLat - minLat, 0.0002);
+  double get lngSpan => max(maxLng - minLng, 0.0002);
 }

--- a/Mobile/mobile_app/lib/features/pages/fence_page.dart
+++ b/Mobile/mobile_app/lib/features/pages/fence_page.dart
@@ -11,6 +11,7 @@ import 'package:smart_livestock_demo/app/session/session_controller.dart';
 import 'package:smart_livestock_demo/core/api/api_cache.dart';
 import 'package:smart_livestock_demo/core/api/api_role.dart';
 import 'package:smart_livestock_demo/core/data/demo_seed.dart';
+import 'package:smart_livestock_demo/core/data/generators/gps_trajectory_generator.dart';
 import 'package:smart_livestock_demo/core/map/map_config.dart';
 import 'package:smart_livestock_demo/core/mock/mock_config.dart';
 import 'package:smart_livestock_demo/core/models/view_state.dart';
@@ -30,6 +31,7 @@ class FencePage extends ConsumerStatefulWidget {
 
 class _FencePageState extends ConsumerState<FencePage> {
   final _mapController = MapController();
+  final _trajectoryGenerator = GpsTrajectoryGenerator(seed: 42);
   bool _panelOpen = false;
 
   @override
@@ -103,6 +105,9 @@ class _FencePageState extends ConsumerState<FencePage> {
     return LayoutBuilder(
       builder: (context, constraints) {
         final panelW = min(300.0, constraints.maxWidth * 0.82);
+        final mockTrajectoryPoints = appMode.isMock
+            ? _buildMockTrajectoryPoints(fenceState)
+            : const <LatLng>[];
         return Stack(
           clipBehavior: Clip.none,
           children: [
@@ -134,6 +139,16 @@ class _FencePageState extends ConsumerState<FencePage> {
                       );
                     }).toList(),
                   ),
+                  if (appMode.isMock && mockTrajectoryPoints.isNotEmpty)
+                    PolylineLayer(
+                      polylines: [
+                        Polyline(
+                          points: mockTrajectoryPoints,
+                          color: AppColors.primary,
+                          strokeWidth: 3,
+                        ),
+                      ],
+                    ),
                   if (appMode.isLive &&
                       ApiCache.instance.initialized &&
                       ApiCache.instance.mapTrajectoryPoints.isNotEmpty)
@@ -337,6 +352,40 @@ class _FencePageState extends ConsumerState<FencePage> {
           ),
         ),
     ];
+  }
+
+  List<LatLng> _buildMockTrajectoryPoints(FenceState fenceState) {
+    final selectedFenceId =
+        fenceState.selectedFenceId ?? 'fence_pasture_a';
+    List<LatLng>? boundary;
+    for (final fence in fenceState.fences) {
+      if (fence.id == selectedFenceId) {
+        boundary = fence.points;
+        break;
+      }
+    }
+    if (boundary == null || boundary.length < 2) {
+      return const [];
+    }
+
+    String? earTag;
+    for (final livestock in DemoSeed.livestock) {
+      if (livestock.fenceId == selectedFenceId) {
+        earTag = livestock.earTag;
+        break;
+      }
+    }
+    final activeEarTag = earTag ?? DemoSeed.earTags.first;
+    final restFence = DemoSeed.fencePointsById('fence_rest');
+    final points = _trajectoryGenerator.generate(
+      earTag: activeEarTag,
+      fenceBoundary: boundary,
+      restFenceBoundary: restFence.isEmpty ? null : restFence,
+      anchorPoints: DemoSeed.gpsAnchorPoints,
+      start: DateTime.utc(2026, 4, 7, 10),
+      end: DateTime.utc(2026, 4, 8, 10),
+    );
+    return points.map((p) => p.toLatLng()).toList();
   }
 
   LatLng _fenceCenter(List<LatLng> points) {

--- a/Mobile/mobile_app/test/generator_test.dart
+++ b/Mobile/mobile_app/test/generator_test.dart
@@ -88,6 +88,108 @@ void main() {
       expect(week7.length, 168);
       expect(identical(day24, week7), isFalse);
     });
+
+    test('enhanced mode keeps nighttime points in rest fence', () {
+      final gen = GpsTrajectoryGenerator(seed: 42);
+      const pastureFence = [
+        LatLng(28.2305, 112.9400),
+        LatLng(28.2340, 112.9440),
+      ];
+      const restFence = [
+        LatLng(28.2280, 112.9380),
+        LatLng(28.2295, 112.9400),
+      ];
+      const anchors = [
+        LatLng(28.2335, 112.9435),
+        LatLng(28.2310, 112.9408),
+      ];
+      final points = gen.generate(
+        earTag: 'SL-2024-001',
+        fenceBoundary: pastureFence,
+        restFenceBoundary: restFence,
+        anchorPoints: anchors,
+        start: DateTime.utc(2026, 4, 1),
+        end: DateTime.utc(2026, 4, 2),
+      );
+      final nightPoints = points.where((p) {
+        final hour = DateTime.parse(p.timestamp).hour;
+        return hour < 6 || hour >= 18;
+      });
+      expect(nightPoints, isNotEmpty);
+      for (final p in nightPoints) {
+        expect(p.lat, greaterThanOrEqualTo(28.2280));
+        expect(p.lat, lessThanOrEqualTo(28.2295));
+        expect(p.lng, greaterThanOrEqualTo(112.9380));
+        expect(p.lng, lessThanOrEqualTo(112.9400));
+      }
+    });
+
+    test('enhanced mode remains deterministic with same inputs', () {
+      final gen = GpsTrajectoryGenerator(seed: 42);
+      const pastureFence = [
+        LatLng(28.2305, 112.9400),
+        LatLng(28.2340, 112.9440),
+      ];
+      const restFence = [
+        LatLng(28.2280, 112.9380),
+        LatLng(28.2295, 112.9400),
+      ];
+      const anchors = [
+        LatLng(28.2335, 112.9435),
+        LatLng(28.2310, 112.9408),
+      ];
+      final a = gen.generate(
+        earTag: 'SL-2024-003',
+        fenceBoundary: pastureFence,
+        restFenceBoundary: restFence,
+        anchorPoints: anchors,
+        start: DateTime.utc(2026, 4, 1),
+        end: DateTime.utc(2026, 4, 2),
+      );
+      final b = gen.generate(
+        earTag: 'SL-2024-003',
+        fenceBoundary: pastureFence,
+        restFenceBoundary: restFence,
+        anchorPoints: anchors,
+        start: DateTime.utc(2026, 4, 1),
+        end: DateTime.utc(2026, 4, 2),
+      );
+      expect(identical(a, b), isTrue);
+      for (var i = 0; i < a.length; i++) {
+        expect(a[i].lat, equals(b[i].lat));
+        expect(a[i].lng, equals(b[i].lng));
+        expect(a[i].timestamp, equals(b[i].timestamp));
+      }
+    });
+
+    test('enhanced cache key separates different anchor sets', () {
+      final gen = GpsTrajectoryGenerator(seed: 42);
+      const pastureFence = [
+        LatLng(28.2305, 112.9400),
+        LatLng(28.2340, 112.9440),
+      ];
+      const restFence = [
+        LatLng(28.2280, 112.9380),
+        LatLng(28.2295, 112.9400),
+      ];
+      final a = gen.generate(
+        earTag: 'SL-2024-005',
+        fenceBoundary: pastureFence,
+        restFenceBoundary: restFence,
+        anchorPoints: const [LatLng(28.2335, 112.9435)],
+        start: DateTime.utc(2026, 4, 1),
+        end: DateTime.utc(2026, 4, 2),
+      );
+      final b = gen.generate(
+        earTag: 'SL-2024-005',
+        fenceBoundary: pastureFence,
+        restFenceBoundary: restFence,
+        anchorPoints: const [LatLng(28.2310, 112.9408)],
+        start: DateTime.utc(2026, 4, 1),
+        end: DateTime.utc(2026, 4, 2),
+      );
+      expect(identical(a, b), isFalse);
+    });
   });
 
   group('TemperatureGenerator', () {


### PR DESCRIPTION
## Summary
- enhance `GpsTrajectoryGenerator` with optional rest-fence and anchor-driven behaviors while keeping deterministic outputs
- update trajectory cache key to include rest-fence and anchor fingerprints for correct memoization boundaries
- render generated trajectory in mock fence map and add generator tests for nighttime rest-area behavior, determinism, and cache separation

## Test plan
- [x] `cd Mobile/mobile_app && flutter analyze`
- [x] `cd Mobile/mobile_app && flutter test test/generator_test.dart`
- [x] `cd Mobile/mobile_app && flutter test`

Closes #4

Made with [Cursor](https://cursor.com)