### PR TITLE
feat(backend): 围栏 CRUD 校验与单测补强 (#17)

### DIFF
--- a/Mobile/backend/data/fenceStore.js
+++ b/Mobile/backend/data/fenceStore.js
@@ -2,6 +2,28 @@ const { fences: seedFences } = require('./seed');
 
 let fences = seedFences.map((f) => ({ ...f }));
 let nextId = fences.length + 1;
+const ALLOWED_TYPES = ['polygon', 'circle', 'rectangle'];
+const ALLOWED_STATUS = ['active', 'inactive'];
+
+function normalizeName(name) {
+  return typeof name === 'string' ? name.trim() : name;
+}
+
+function isValidCoordinates(coordinates) {
+  if (!Array.isArray(coordinates) || coordinates.length < 3) {
+    return false;
+  }
+  for (const point of coordinates) {
+    if (!Array.isArray(point) || point.length !== 2) {
+      return false;
+    }
+    const [lng, lat] = point;
+    if (!Number.isFinite(lng) || !Number.isFinite(lat)) {
+      return false;
+    }
+  }
+  return true;
+}
 
 function getAll() {
   return fences;
@@ -12,9 +34,24 @@ function findById(id) {
 }
 
 function createFence(body) {
-  const { name, type = 'polygon', coordinates = [], alarmEnabled = true } = body || {};
+  const {
+    name: rawName,
+    type = 'polygon',
+    coordinates = [],
+    alarmEnabled = true,
+  } = body || {};
+  const name = normalizeName(rawName);
   if (!name) {
     return { error: 'name_required' };
+  }
+  if (!ALLOWED_TYPES.includes(type)) {
+    return { error: 'type_invalid' };
+  }
+  if (!isValidCoordinates(coordinates)) {
+    return { error: 'coordinates_invalid' };
+  }
+  if (typeof alarmEnabled !== 'boolean') {
+    return { error: 'alarm_enabled_invalid' };
   }
   const fence = {
     id: `fence_${String(nextId++).padStart(3, '0')}`,
@@ -33,7 +70,29 @@ function updateFence(id, body) {
   if (!fence) {
     return { error: 'not_found' };
   }
-  const { name, type, coordinates, alarmEnabled, status } = body || {};
+  const {
+    name: rawName,
+    type,
+    coordinates,
+    alarmEnabled,
+    status,
+  } = body || {};
+  const name = normalizeName(rawName);
+  if (rawName !== undefined && !name) {
+    return { error: 'name_required' };
+  }
+  if (type !== undefined && !ALLOWED_TYPES.includes(type)) {
+    return { error: 'type_invalid' };
+  }
+  if (coordinates !== undefined && !isValidCoordinates(coordinates)) {
+    return { error: 'coordinates_invalid' };
+  }
+  if (alarmEnabled !== undefined && typeof alarmEnabled !== 'boolean') {
+    return { error: 'alarm_enabled_invalid' };
+  }
+  if (status !== undefined && !ALLOWED_STATUS.includes(status)) {
+    return { error: 'status_invalid' };
+  }
   if (name !== undefined) fence.name = name;
   if (type !== undefined) fence.type = type;
   if (coordinates !== undefined) fence.coordinates = coordinates;
@@ -60,6 +119,11 @@ function sliceForPage(page, pageSize) {
   return { items, page: p, pageSize: ps, total };
 }
 
+function reset() {
+  fences = seedFences.map((f) => ({ ...f }));
+  nextId = fences.length + 1;
+}
+
 module.exports = {
   getAll,
   findById,
@@ -67,4 +131,5 @@ module.exports = {
   updateFence,
   removeFence,
   sliceForPage,
+  reset,
 };

--- a/Mobile/backend/package.json
+++ b/Mobile/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "node --watch server.js",
-    "test": "node test/geo.test.js"
+    "test": "node test/geo.test.js && node test/fenceStore.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/Mobile/backend/routes/fences.js
+++ b/Mobile/backend/routes/fences.js
@@ -4,6 +4,25 @@ const fenceStore = require('../data/fenceStore');
 
 const router = Router();
 
+function handleValidationError(res, error) {
+  if (error === 'name_required') {
+    return res.fail(422, 'VALIDATION_ERROR', 'name 为必填项');
+  }
+  if (error === 'type_invalid') {
+    return res.fail(422, 'VALIDATION_ERROR', 'type 必须为 polygon / circle / rectangle');
+  }
+  if (error === 'coordinates_invalid') {
+    return res.fail(422, 'VALIDATION_ERROR', 'coordinates 必须为至少 3 个有效坐标点');
+  }
+  if (error === 'alarm_enabled_invalid') {
+    return res.fail(422, 'VALIDATION_ERROR', 'alarmEnabled 必须为布尔值');
+  }
+  if (error === 'status_invalid') {
+    return res.fail(422, 'VALIDATION_ERROR', 'status 必须为 active / inactive');
+  }
+  return null;
+}
+
 router.get(
   '/',
   authMiddleware,
@@ -14,14 +33,28 @@ router.get(
   },
 );
 
+router.get(
+  '/:id',
+  authMiddleware,
+  requirePermission('fence:view'),
+  (req, res) => {
+    const { id } = req.params;
+    const fence = fenceStore.findById(id);
+    if (!fence) {
+      return res.fail(404, 'RESOURCE_NOT_FOUND', '围栏不存在');
+    }
+    res.ok(fence);
+  },
+);
+
 router.post(
   '/',
   authMiddleware,
   requirePermission('fence:manage'),
   (req, res) => {
     const result = fenceStore.createFence(req.body || {});
-    if (result.error === 'name_required') {
-      return res.fail(422, 'VALIDATION_ERROR', 'name 为必填项');
+    if (result.error) {
+      return handleValidationError(res, result.error);
     }
     res.ok(result.fence);
   },
@@ -36,6 +69,9 @@ router.put(
     const result = fenceStore.updateFence(id, req.body || {});
     if (result.error === 'not_found') {
       return res.fail(404, 'RESOURCE_NOT_FOUND', '围栏不存在');
+    }
+    if (result.error) {
+      return handleValidationError(res, result.error);
     }
     res.ok(result.fence);
   },

--- a/Mobile/backend/server.js
+++ b/Mobile/backend/server.js
@@ -51,6 +51,7 @@ const ROUTE_TABLE = [
   ['POST',   '/api/alerts/:id/archive'],
   ['POST',   '/api/alerts/batch-handle'],
   ['GET',    '/api/fences'],
+  ['GET',    '/api/fences/:id'],
   ['POST',   '/api/fences'],
   ['PUT',    '/api/fences/:id'],
   ['DELETE', '/api/fences/:id'],

--- a/Mobile/backend/test/fenceStore.test.js
+++ b/Mobile/backend/test/fenceStore.test.js
@@ -1,0 +1,82 @@
+const assert = require('assert');
+const fenceStore = require('../data/fenceStore');
+
+fenceStore.reset();
+
+const created = fenceStore.createFence({
+  name: '  新围栏  ',
+  type: 'rectangle',
+  coordinates: [
+    [112.1, 28.1],
+    [112.2, 28.2],
+    [112.3, 28.3],
+  ],
+  alarmEnabled: false,
+});
+assert.ok(!created.error);
+assert.strictEqual(created.fence.name, '新围栏');
+assert.strictEqual(created.fence.type, 'rectangle');
+assert.strictEqual(created.fence.alarmEnabled, false);
+
+const invalidCreate = fenceStore.createFence({
+  name: '',
+  type: 'triangle',
+  coordinates: [[112.1, 28.1]],
+});
+assert.strictEqual(invalidCreate.error, 'name_required');
+
+const invalidType = fenceStore.createFence({
+  name: '围栏2',
+  type: 'triangle',
+});
+assert.strictEqual(invalidType.error, 'type_invalid');
+
+const invalidCoordinates = fenceStore.createFence({
+  name: '围栏3',
+  coordinates: [[112.1, 28.1]],
+});
+assert.strictEqual(invalidCoordinates.error, 'coordinates_invalid');
+
+const invalidAlarmEnabled = fenceStore.createFence({
+  name: '围栏4',
+  coordinates: [
+    [112.1, 28.1],
+    [112.2, 28.2],
+    [112.3, 28.3],
+  ],
+  alarmEnabled: 'yes',
+});
+assert.strictEqual(invalidAlarmEnabled.error, 'alarm_enabled_invalid');
+
+const existedFence = fenceStore.getAll()[0];
+const updated = fenceStore.updateFence(existedFence.id, {
+  name: '  更新后围栏  ',
+  status: 'inactive',
+});
+assert.ok(!updated.error);
+assert.strictEqual(updated.fence.name, '更新后围栏');
+assert.strictEqual(updated.fence.status, 'inactive');
+
+const invalidUpdateStatus = fenceStore.updateFence(existedFence.id, {
+  status: 'disabled',
+});
+assert.strictEqual(invalidUpdateStatus.error, 'status_invalid');
+
+const invalidUpdateName = fenceStore.updateFence(existedFence.id, {
+  name: '   ',
+});
+assert.strictEqual(invalidUpdateName.error, 'name_required');
+
+const notFoundUpdate = fenceStore.updateFence('missing-id', {
+  name: 'x',
+});
+assert.strictEqual(notFoundUpdate.error, 'not_found');
+
+const removed = fenceStore.removeFence(existedFence.id);
+assert.ok(!removed.error);
+assert.strictEqual(removed.removed.id, existedFence.id);
+
+const notFoundRemove = fenceStore.removeFence('missing-id');
+assert.strictEqual(notFoundRemove.error, 'not_found');
+
+console.log('fenceStore.test.js OK');

--- a/Mobile/docs/superpowers/plans/2026-04-14-backend-fence-crud-hardening.md
+++ b/Mobile/docs/superpowers/plans/2026-04-14-backend-fence-crud-hardening.md
@@ -1,0 +1,42 @@
+# Mock Server 围栏 CRUD 补强实施计划
+
+**Goal:** 在不改动现有前端交互的前提下，补齐后端围栏 CRUD 的参数校验、详情查询接口与单元测试，提升联调稳定性。
+
+**Scope:** `Mobile/backend`（Express mock server）
+
+---
+
+## Issue 索引
+
+| 优先级 | Issue | 标题 |
+|--------|-------|------|
+| P1 | [#17](https://github.com/aime4eve/smart-livestock/issues/17) | Mock Server 围栏 CRUD 补强：参数校验、详情接口与单测 |
+
+### 完成记录
+
+| 完成日期 | Issue | PR | 备注 |
+|----------|-------|----|------|
+
+---
+
+## #17 — Mock Server 围栏 CRUD 补强
+
+### 目标
+
+- 新增 `GET /api/fences/:id`，支持按 ID 查询围栏
+- 强化 `POST /api/fences` 与 `PUT /api/fences/:id` 参数校验
+- 为 `fenceStore` 新增独立测试文件并纳入 `npm test`
+
+### 涉及文件
+
+- `Mobile/backend/routes/fences.js`
+- `Mobile/backend/data/fenceStore.js`
+- `Mobile/backend/server.js`
+- `Mobile/backend/package.json`
+- `Mobile/backend/test/fenceStore.test.js`
+
+### 验收标准
+
+- `cd Mobile/backend && npm test` 通过
+- 创建/更新围栏错误请求返回 `422 VALIDATION_ERROR`
+- 详情接口不存在资源返回 `404 RESOURCE_NOT_FOUND`


### PR DESCRIPTION
## Summary
- 新增 `GET /api/fences/:id` 详情接口，补齐围栏查询能力
- 强化 `fenceStore` 对 `name/type/coordinates/alarmEnabled/status` 的校验逻辑，并统一路由层 422 响应映射
- 增加 `fenceStore.test.js` 并将其纳入 `npm test`，同时补充 issue-driven plan 文件

## Test plan
- [x] `cd Mobile/backend && npm test`
- [x] `cd Mobile/mobile_app && flutter analyze`

Closes #17

Made with [Cursor](https://cursor.com)