### PR TITLE
fix(mobile): 围栏编辑模式独占与 Web 启动稳定性

### DIFF
--- a/Mobile/dev.sh
+++ b/Mobile/dev.sh
@@ -7,6 +7,7 @@
 #   ./dev.sh stop           # 停止所有服务
 #   ./dev.sh restart [mock|live]  # 重启所有服务
 #   ./dev.sh status         # 查看服务状态
+#   ./dev.sh diagnose       # 打印最近日志与关键错误行（便于白屏/WASM 等问题排查）
 
 set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -58,15 +59,20 @@ start_backend() {
 
 # ---------- 启动 Flutter App ----------
 start_flutter() {
-  local mode="${1:-mock}"
+  local mode="${1:-live}"
+  local device="${2:-chrome}"
 
   if is_running flutter; then
     warn "Flutter App 已在运行 (PID $(cat "$PID_DIR/flutter.pid"))"
     return 0
   fi
 
-  info "启动 Flutter App (APP_MODE=$mode)..."
-  (cd "$MOBILE_DIR" && flutter run --dart-define=APP_MODE="$mode" > "$LOG_DIR/flutter.log" 2>&1) &
+  info "启动 Flutter App (APP_MODE=$mode, device=$device)..."
+  if [[ "$device" == "chrome" ]]; then
+    (cd "$MOBILE_DIR" && flutter run -d "$device" --no-web-resources-cdn --dart-define=APP_MODE="$mode" > "$LOG_DIR/flutter.log" 2>&1) &
+  else
+    (cd "$MOBILE_DIR" && flutter run -d "$device" --dart-define=APP_MODE="$mode" > "$LOG_DIR/flutter.log" 2>&1) &
+  fi
   local pid=$!
   echo "$pid" > "$PID_DIR/flutter.pid"
   info "Flutter App 已启动 (PID $pid, APP_MODE=$mode)"
@@ -154,6 +160,42 @@ show_logs() {
   fi
 }
 
+# ---------- 诊断（最近日志 + 关键行） ----------
+diagnose() {
+  ensure_dirs
+  echo ""
+  info "=== 进程状态 ==="
+  show_status
+  echo ""
+  local flutter_log="$LOG_DIR/flutter.log"
+  local backend_log="$LOG_DIR/backend.log"
+
+  if [[ -f "$flutter_log" ]]; then
+    info "=== Flutter 最近 100 行 ($flutter_log) ==="
+    tail -n 100 "$flutter_log"
+  else
+    warn "Flutter 日志不存在: $flutter_log（可能未用本脚本启动或未产生日志）"
+  fi
+  echo ""
+  if [[ -f "$backend_log" ]]; then
+    info "=== Mock Server 最近 100 行 ($backend_log) ==="
+    tail -n 100 "$backend_log"
+  else
+    warn "Backend 日志不存在: $backend_log"
+  fi
+  echo ""
+  if [[ -f "$flutter_log" ]]; then
+    info "=== Flutter 关键行（匹配 error/exception/fail/abort/wasm 等，最多 50 行）==="
+    grep -E -i 'error|exception|fail|abort|fatal|TypeError|webassembly|wasm|rejected|cannot|unhandled' "$flutter_log" 2>/dev/null | tail -n 50 || true
+  fi
+  if [[ -f "$backend_log" ]]; then
+    info "=== Mock Server 关键行（同上，最多 50 行）==="
+    grep -E -i 'error|exception|fail|abort|fatal|EADDRINUSE|listen|ECONNREFUSED' "$backend_log" 2>/dev/null | tail -n 50 || true
+  fi
+  echo ""
+  info "完整日志目录: $LOG_DIR/"
+}
+
 # ---------- 清理 ----------
 cleanup() {
   echo ""
@@ -164,28 +206,37 @@ cleanup() {
 
 # ---------- 主入口 ----------
 case "${1:-help}" in
+  start_live)
+    start_backend
+    start_flutter "live" "chrome"
+    ;;
+  start_mock)
+    start_backend
+    start_flutter "mock" "chrome"
+    ;;
   start)
     ensure_dirs
     # 注册退出清理
     trap cleanup INT TERM
 
-    local mode="${2:-mock}"
+    mode="${2:-mock}"
+    device="${3:-chrome}"
     if [[ "$mode" != "mock" && "$mode" != "live" ]]; then
       error "无效模式: $mode（可选 mock / live）"
       exit 1
     fi
 
     start_backend
-    # live 模式需要等 Mock Server 就绪
     if [[ "$mode" == "live" ]]; then
       info "等待 Mock Server 就绪..."
       sleep 1
     fi
-    start_flutter "$mode"
+    start_flutter "$mode" "$device"
 
     info "========================================="
     info "  所有服务已启动"
     info "  模式: $mode"
+    info "  设备: $device"
     info "  Mock Server: http://localhost:3001"
     info "  日志目录: $LOG_DIR/"
     info "  按 Ctrl+C 停止所有服务"
@@ -202,7 +253,7 @@ case "${1:-help}" in
   restart)
     stop_all
     sleep 1
-    exec "$0" start "${2:-mock}"
+    exec "$0" start "${2:-mock}" "${3:-chrome}"
     ;;
 
   status)
@@ -217,14 +268,19 @@ case "${1:-help}" in
     esac
     ;;
 
+  diagnose)
+    diagnose
+    ;;
+
   help|*)
     echo "智慧畜牧 App 开发控制脚本"
     echo ""
     echo "用法:"
-    echo "  $0 start [mock|live]   启动所有服务（默认 mock 模式）"
-    echo "  $0 stop                停止所有服务"
-    echo "  $0 restart [mock|live] 重启所有服务"
-    echo "  $0 status              查看服务状态"
-    echo "  $0 logs [backend|flutter]  查看日志（实时跟踪）"
+    echo "  $0 start [mock|live] [chrome|macos]  启动所有服务（默认 mock + chrome）"
+    echo "  $0 stop                              停止所有服务"
+    echo "  $0 restart [mock|live] [chrome|macos] 重启所有服务"
+    echo "  $0 status                            查看服务状态"
+    echo "  $0 logs [backend|flutter]            查看日志（实时跟踪）"
+    echo "  $0 diagnose                          诊断：最近 100 行日志 + 关键错误行"
     ;;
 esac

--- a/Mobile/mobile_app/lib/features/fence/presentation/widgets/fence_edit_overlay.dart
+++ b/Mobile/mobile_app/lib/features/fence/presentation/widgets/fence_edit_overlay.dart
@@ -46,6 +46,22 @@ class _FenceEditOverlayState extends State<FenceEditOverlay> {
 
   final _gestureKey = GlobalKey();
   Offset? _lastTranslateOffset;
+  int? _draggingVertexIndex;
+
+  @override
+  void didUpdateWidget(covariant FenceEditOverlay oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.activeTool != widget.activeTool) {
+      _draggingVertexIndex = null;
+    } else if (widget.activeTool == FenceEditTool.moveVertex &&
+        oldWidget.points.length != widget.points.length) {
+      _draggingVertexIndex = null;
+    }
+    if (_draggingVertexIndex != null &&
+        _draggingVertexIndex! >= widget.points.length) {
+      _draggingVertexIndex = null;
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -56,6 +72,11 @@ class _FenceEditOverlayState extends State<FenceEditOverlay> {
     final initialCenter =
         widget.points.isNotEmpty ? widget.points.first : DemoSeed.mapCenter;
     final translateHitPolygon = _translateHitPolygon();
+    final mapInteractionFlags =
+        widget.activeTool == FenceEditTool.moveVertex ||
+                widget.activeTool == FenceEditTool.translate
+            ? InteractiveFlag.none
+            : InteractiveFlag.all;
 
     return Positioned.fill(
       child: Container(
@@ -63,19 +84,22 @@ class _FenceEditOverlayState extends State<FenceEditOverlay> {
         color: AppColors.surface,
         child: Stack(
           children: [
-            GestureDetector(
+            Container(
               key: _gestureKey,
-              behavior: HitTestBehavior.translucent,
-              onTapUp: widget.isInteractive ? _handleTapUp : null,
+              color: Colors.transparent,
               child: FlutterMap(
                 key: const Key('fence-edit-map'),
                 mapController: widget.mapController,
                 options: MapOptions(
                   initialCenter: initialCenter,
                   initialZoom: 16,
-                  interactionOptions: const InteractionOptions(
-                    flags: InteractiveFlag.all,
+                  interactionOptions: InteractionOptions(
+                    flags: mapInteractionFlags,
                   ),
+                  onTap: widget.isInteractive &&
+                          widget.activeTool == FenceEditTool.insertVertex
+                      ? _handleMapTapInsert
+                      : null,
                 ),
                 children: [
                   TileLayer(
@@ -110,22 +134,63 @@ class _FenceEditOverlayState extends State<FenceEditOverlay> {
                         Marker(
                           key: Key('fence-edit-vertex-marker-$i'),
                           point: widget.points[i],
-                          width: 36,
-                          height: 36,
+                          width: 88,
+                          height: 88,
+                          alignment: Alignment.center,
                           child: GestureDetector(
                             key: Key('fence-edit-vertex-$i'),
                             behavior: HitTestBehavior.opaque,
-                            onTap: widget.isInteractive &&
-                                    widget.activeTool == FenceEditTool.deleteVertex
-                                ? () => widget.onRemoveVertex(i)
+                            onTap: widget.isInteractive
+                                ? () {
+                                    if (widget.activeTool ==
+                                        FenceEditTool.deleteVertex) {
+                                      widget.onRemoveVertex(i);
+                                    }
+                                  }
+                                : null,
+                            onPanStart: widget.isInteractive &&
+                                    widget.activeTool ==
+                                        FenceEditTool.moveVertex
+                                ? (_) {
+                                    setState(() => _draggingVertexIndex = i);
+                                  }
                                 : null,
                             onPanUpdate: widget.isInteractive &&
-                                    widget.activeTool == FenceEditTool.moveVertex
-                                ? (details) => _handleVertexPanUpdate(i, details.globalPosition)
+                                    widget.activeTool ==
+                                        FenceEditTool.moveVertex
+                                ? (details) {
+                                    if (_draggingVertexIndex != i) {
+                                      return;
+                                    }
+                                    _handleVertexPanUpdate(
+                                      i,
+                                      details.globalPosition,
+                                    );
+                                  }
                                 : null,
-                            child: _VertexHandle(
-                              highlight: widget.activeTool == FenceEditTool.moveVertex ||
-                                  widget.activeTool == FenceEditTool.deleteVertex,
+                            onPanEnd: widget.isInteractive &&
+                                    widget.activeTool ==
+                                        FenceEditTool.moveVertex
+                                ? (_) {
+                                    setState(() => _draggingVertexIndex = null);
+                                  }
+                                : null,
+                            onPanCancel: widget.isInteractive &&
+                                    widget.activeTool ==
+                                        FenceEditTool.moveVertex
+                                ? () {
+                                    setState(() => _draggingVertexIndex = null);
+                                  }
+                                : null,
+                            child: Center(
+                              child: _VertexHandle(
+                                highlight: widget.activeTool ==
+                                        FenceEditTool.moveVertex ||
+                                    widget.activeTool ==
+                                        FenceEditTool.deleteVertex,
+                                selected: false,
+                                dimmed: false,
+                              ),
                             ),
                           ),
                         ),
@@ -187,19 +252,24 @@ class _FenceEditOverlayState extends State<FenceEditOverlay> {
     );
   }
 
-  void _handleTapUp(TapUpDetails details) {
-    if (widget.activeTool != FenceEditTool.insertVertex) {
+  void _handleMapTapInsert(TapPosition tapPosition, LatLng _) {
+    if (!widget.isInteractive ||
+        widget.activeTool != FenceEditTool.insertVertex) {
       return;
     }
-    final edgeHit = _findNearestEdge(details.localPosition);
+    final local = tapPosition.relative;
+    if (local == null) {
+      return;
+    }
+    final edgeHit = _findNearestEdge(local);
     if (edgeHit == null || edgeHit.distance > _edgeHitThreshold) {
       return;
     }
-    final point = _latLngFromLocal(details.localPosition);
-    if (point == null) {
+    final insertPoint = _latLngFromLocal(local);
+    if (insertPoint == null) {
       return;
     }
-    widget.onInsertVertex(edgeHit.edgeStartIndex, point);
+    widget.onInsertVertex(edgeHit.edgeStartIndex, insertPoint);
   }
 
   void _handlePanStart(DragStartDetails details) {
@@ -335,31 +405,57 @@ class _FenceEditOverlayState extends State<FenceEditOverlay> {
 }
 
 class _VertexHandle extends StatelessWidget {
-  const _VertexHandle({required this.highlight});
+  const _VertexHandle({
+    required this.highlight,
+    this.selected = false,
+    this.dimmed = false,
+  });
+
+  static const double _outerDiameter = 44;
 
   final bool highlight;
+  final bool selected;
+  final bool dimmed;
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(
-        color: highlight ? AppColors.primary : Colors.white,
-        shape: BoxShape.circle,
-        border: Border.all(
-          color: highlight ? Colors.white : AppColors.primary,
-          width: 2,
+    final effectiveHighlight = highlight && !dimmed;
+    final outerColor = selected || effectiveHighlight
+        ? AppColors.primary
+        : Colors.white;
+    const borderColor = AppColors.primary;
+    final innerColor = selected || effectiveHighlight
+        ? Colors.white
+        : AppColors.primary;
+    const borderWidth = 2.0;
+    const innerDot = 10.0;
+
+    return SizedBox(
+      width: _outerDiameter,
+      height: _outerDiameter,
+      child: Container(
+        decoration: BoxDecoration(
+          color: outerColor,
+          shape: BoxShape.circle,
+          border: Border.all(
+            color: borderColor,
+            width: borderWidth,
+          ),
+          boxShadow: const [
+            BoxShadow(
+              color: Colors.black26,
+              blurRadius: 4,
+            ),
+          ],
         ),
-        boxShadow: const [
-          BoxShadow(color: Colors.black26, blurRadius: 4),
-        ],
-      ),
-      child: Center(
-        child: Container(
-          width: 8,
-          height: 8,
-          decoration: BoxDecoration(
-            color: highlight ? Colors.white : AppColors.primary,
-            shape: BoxShape.circle,
+        child: Center(
+          child: Container(
+            width: innerDot,
+            height: innerDot,
+            decoration: BoxDecoration(
+              color: innerColor,
+              shape: BoxShape.circle,
+            ),
           ),
         ),
       ),

--- a/Mobile/mobile_app/lib/features/pages/fence_page.dart
+++ b/Mobile/mobile_app/lib/features/pages/fence_page.dart
@@ -19,6 +19,7 @@ import 'package:smart_livestock_demo/core/permissions/role_permission.dart';
 import 'package:smart_livestock_demo/core/theme/app_colors.dart';
 import 'package:smart_livestock_demo/core/theme/app_spacing.dart';
 import 'package:smart_livestock_demo/features/fence/domain/fence_item.dart';
+import 'package:smart_livestock_demo/features/fence/domain/fence_polygon_contains.dart';
 import 'package:smart_livestock_demo/features/fence/domain/fence_edit_session.dart';
 import 'package:smart_livestock_demo/features/fence/domain/fence_state.dart';
 import 'package:smart_livestock_demo/features/fence/presentation/fence_controller.dart';
@@ -34,19 +35,45 @@ class FencePage extends ConsumerStatefulWidget {
 }
 
 class _FencePageState extends ConsumerState<FencePage> {
-  final _mapController = MapController();
+  final _browseMapController = MapController();
+  final _editMapController = MapController();
   final _trajectoryGenerator = GpsTrajectoryGenerator(seed: 42);
   bool _panelOpen = false;
 
   @override
   void dispose() {
-    _mapController.dispose();
+    _browseMapController.dispose();
+    _editMapController.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
     final fenceState = ref.watch(fenceControllerProvider);
+    ref.listen<FenceState>(fenceControllerProvider, (previous, next) {
+      if (previous == null) {
+        return;
+      }
+      final hadSession = previous.editSession;
+      final hasSession = next.editSession;
+      if (hadSession == null && hasSession != null) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted) {
+            return;
+          }
+          final c = _browseMapController.camera;
+          _editMapController.move(c.center, c.zoom);
+        });
+      } else if (hadSession != null && hasSession == null) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (!mounted) {
+            return;
+          }
+          final c = _editMapController.camera;
+          _browseMapController.move(c.center, c.zoom);
+        });
+      }
+    });
     final role = ref.watch(sessionControllerProvider).role!;
     final canManage = RolePermission.canEditFence(role);
 
@@ -124,7 +151,7 @@ class _FencePageState extends ConsumerState<FencePage> {
       return Stack(
         children: [
           FenceEditOverlay(
-            mapController: _mapController,
+            mapController: _editMapController,
             points: editSession.points,
             isInteractive: !isSaving,
             activeTool: editSession.tool,
@@ -178,12 +205,18 @@ class _FencePageState extends ConsumerState<FencePage> {
           children: [
             Positioned.fill(
               child: FlutterMap(
-                mapController: _mapController,
-                options: const MapOptions(
+                key: const Key('fence-browse-map'),
+                mapController: _browseMapController,
+                options: MapOptions(
                   initialCenter: DemoSeed.mapCenter,
                   initialZoom: DemoSeed.defaultZoom,
-                  interactionOptions: InteractionOptions(
+                  interactionOptions: const InteractionOptions(
                     flags: InteractiveFlag.all,
+                  ),
+                  onTap: (tapPosition, point) => _handleMapTap(
+                    point,
+                    fenceState,
+                    controller,
                   ),
                 ),
                 children: [
@@ -315,23 +348,21 @@ class _FencePageState extends ConsumerState<FencePage> {
                                 canManage: canManage,
                                 onTap: () {
                                   controller.select(fence.id);
-                                  _mapController.move(
+                                  _browseMapController.move(
                                     _fenceCenter(fence.points),
                                     16.0,
                                   );
                                   setState(() => _panelOpen = false);
                                 },
-                                onEdit: () => context
-                                    .push(
-                                  '${AppRoute.fenceForm.path}?id=${fence.id}',
-                                )
-                                    .then((_) {
-                                  if (appMode.isLive) {
-                                    ref
-                                        .read(fenceControllerProvider.notifier)
-                                        .reloadFromRepository();
-                                  }
-                                }),
+                                onEdit: () {
+                                  controller.select(fence.id);
+                                  controller.startEditing(fence.id);
+                                  _browseMapController.move(
+                                    _fenceCenter(fence.points),
+                                    16.0,
+                                  );
+                                  setState(() => _panelOpen = false);
+                                },
                                 onDelete: () => _showDeleteDialog(
                                   context,
                                   fence,
@@ -370,12 +401,20 @@ class _FencePageState extends ConsumerState<FencePage> {
                 child: FloatingActionButton.extended(
                   key: const Key('fence-start-edit'),
                   heroTag: 'fence-start-edit',
-                  onPressed: selectedFenceId == null
-                      ? null
-                      : () {
-                          controller.startEditing(selectedFenceId);
-                          setState(() => _panelOpen = false);
-                        },
+                  onPressed: () {
+                    if (selectedFenceId == null) {
+                      ScaffoldMessenger.of(context)
+                        ..hideCurrentSnackBar()
+                        ..showSnackBar(
+                          const SnackBar(
+                            content: Text('请先选择一个牧场'),
+                          ),
+                        );
+                      return;
+                    }
+                    controller.startEditing(selectedFenceId);
+                    setState(() => _panelOpen = false);
+                  },
                   icon: const Icon(Icons.edit_location_alt_outlined),
                   label: const Text('编辑边界'),
                 ),
@@ -614,6 +653,21 @@ class _FencePageState extends ConsumerState<FencePage> {
       lng += p.longitude;
     }
     return LatLng(lat / points.length, lng / points.length);
+  }
+
+  void _handleMapTap(
+    LatLng point,
+    FenceState fenceState,
+    FenceController controller,
+  ) {
+    for (final fence in fenceState.fences) {
+      if (fencePolygonContainsLatLng(point, fence.points)) {
+        controller.select(fence.id);
+        _browseMapController.move(_fenceCenter(fence.points), 16.0);
+        return;
+      }
+    }
+    controller.select(null);
   }
 
   void _showDeleteDialog(

--- a/Mobile/mobile_app/lib/main.dart
+++ b/Mobile/mobile_app/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/semantics.dart';
 import 'package:flutter/widgets.dart';
@@ -19,10 +21,10 @@ void main() async {
     const String.fromEnvironment('APP_MODE', defaultValue: 'mock'),
   );
 
+  runApp(DemoApp(appMode: appMode));
+
   if (appMode.isLive) {
     const apiRole = String.fromEnvironment('API_ROLE', defaultValue: 'owner');
-    await ApiCache.instance.init(apiRole);
+    unawaited(ApiCache.instance.init(apiRole));
   }
-
-  runApp(const DemoApp());
 }

--- a/Mobile/mobile_app/test/features/fence/fence_page_mode_switch_test.dart
+++ b/Mobile/mobile_app/test/features/fence/fence_page_mode_switch_test.dart
@@ -14,15 +14,29 @@ void main() {
     ApiCache.instance.lastFenceSaveStatusCode = null;
   });
 
-  testWidgets('未选中围栏时编辑入口禁用且不会误编辑第一条', (tester) async {
+  testWidgets('未选中围栏时点击编辑边界显示提示且不进入编辑态', (tester) async {
     await _openFencePage(tester);
 
-    final FloatingActionButton button = tester.widget<FloatingActionButton>(
+    final fab = tester.widget<FloatingActionButton>(
       find.byKey(const Key('fence-start-edit')),
     );
+    expect(fab.onPressed, isNotNull);
 
-    expect(button.onPressed, isNull);
+    await tester.tap(find.byKey(const Key('fence-start-edit')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('请先选择一个牧场'), findsOneWidget);
     expect(find.byKey(const Key('fence-edit-overlay')), findsNothing);
+  });
+
+  testWidgets('侧栏编辑按钮直接进入边界编辑', (tester) async {
+    await _openFencePage(tester);
+    await tester.tap(find.byKey(const Key('fence-panel-toggle')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const Key('fence-edit-fence_pasture_a')));
+    await tester.pumpAndSettle();
+
+    expect(find.byKey(const Key('fence-edit-overlay')), findsOneWidget);
   });
 
   testWidgets('进入编辑全屏后可直接退出并恢复浏览列表', (tester) async {


### PR DESCRIPTION
## 摘要

围栏编辑后续修正（关联 #21 已合并实现，关闭 #22 中待跟进项）：

- **模式独占**：`拖点` / `平移` 下将 `flutter_map` 交互设为 `InteractiveFlag.none`，避免与地图平移/缩放手势冲突；插点/删点仍保留完整地图交互。
- **双 MapController**：浏览态与编辑态使用独立 `MapController`，进入/退出编辑时同步相机，避免 `flutter_map` 与共享控制器在切换时的异常与测试不稳定。
- **Live 启动**：`runApp` 后再异步 `ApiCache.init`，避免 Web 长时间白屏。
- **Web 资源**：`Mobile/dev.sh` 在 `chrome` 下增加 `--no-web-resources-cdn`，减轻 WASM/CDN 加载中断导致的 `WebAssembly compilation aborted`。
- **诊断**：`./dev.sh diagnose` 输出最近日志与关键错误行。

## 测试

- `cd Mobile/mobile_app && flutter analyze`（相关文件）
- `cd Mobile/mobile_app && flutter test test/features/fence/`

## 关联

- Closes #22
- Related #21
