### PR TITLE
feat(api): add v1 auth migration path

### DIFF
--- a/Mobile/backend/config/runtimeConfig.js
+++ b/Mobile/backend/config/runtimeConfig.js
@@ -1,0 +1,35 @@
+function parseBool(value, fallback = false) {
+  if (value === undefined) return fallback;
+  return value === 'true' || value === true;
+}
+
+function buildRuntimeConfig(env = process.env) {
+  const nodeEnv = env.NODE_ENV || 'development';
+  const allowedEnvs = (env.MOCK_TOKEN_ALLOWED_ENVS || 'dev,development,staging')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+  const breakGlass = parseBool(env.MOCK_TOKEN_BREAK_GLASS);
+  const breakGlassExpiresAt = env.MOCK_TOKEN_BREAK_GLASS_EXPIRES_AT || null;
+  const requestedMockToken = parseBool(env.ENABLE_MOCK_TOKEN);
+
+  let enableMockToken = requestedMockToken && allowedEnvs.includes(nodeEnv);
+
+  if (nodeEnv === 'production' && requestedMockToken) {
+    const expiresAt = breakGlassExpiresAt ? Date.parse(breakGlassExpiresAt) : Number.NaN;
+    const isValidBreakGlass = breakGlass && Number.isFinite(expiresAt) && expiresAt > Date.now();
+    if (!isValidBreakGlass) {
+      throw new Error('mock-token cannot be enabled in production without unexpired break-glass');
+    }
+    enableMockToken = true;
+  }
+
+  return {
+    nodeEnv,
+    enableMockToken,
+    allowedMockTokenEnvs: allowedEnvs,
+    exposeDebugHeaders: parseBool(env.EXPOSE_API_DEBUG_HEADERS, nodeEnv !== 'production'),
+  };
+}
+
+module.exports = { buildRuntimeConfig };

--- a/Mobile/backend/middleware/auth.js
+++ b/Mobile/backend/middleware/auth.js
@@ -1,4 +1,6 @@
 const { users } = require('../data/seed');
+const { buildRuntimeConfig } = require('../config/runtimeConfig');
+const { verifyAccessToken } = require('../services/mockTokenService');
 
 /**
  * Map token -> role for simple mock auth
@@ -12,23 +14,44 @@ const TOKEN_MAP = {
 /**
  * Extract role from Bearer token
  */
-function extractRole(req) {
+function extractBearerToken(req) {
   const auth = req.headers.authorization || '';
   if (!auth.startsWith('Bearer ')) return null;
-  const token = auth.slice(7);
-  return TOKEN_MAP[token] || null;
+  return auth.slice(7);
 }
 
 /**
  * Auth middleware: sets req.userRole and req.user
  */
 function authMiddleware(req, res, next) {
-  const role = extractRole(req);
+  const token = extractBearerToken(req);
+  if (!token) {
+    return res.fail(401, 'AUTH_UNAUTHORIZED', '未登录或 token 失效');
+  }
+
+  const jwtUser = verifyAccessToken(token);
+  if (jwtUser) {
+    const runtimeConfig = buildRuntimeConfig(process.env);
+    req.userRole = jwtUser.role;
+    req.user = jwtUser;
+    req.authMode = 'jwt';
+    if (runtimeConfig.exposeDebugHeaders) {
+      res.setHeader('X-Auth-Mode', req.authMode);
+    }
+    return next();
+  }
+
+  const runtimeConfig = buildRuntimeConfig(process.env);
+  const role = runtimeConfig.enableMockToken ? TOKEN_MAP[token] : null;
   if (!role) {
     return res.fail(401, 'AUTH_UNAUTHORIZED', '未登录或 token 失效');
   }
   req.userRole = role;
   req.user = users[role];
+  req.authMode = 'mock';
+  if (runtimeConfig.exposeDebugHeaders) {
+    res.setHeader('X-Auth-Mode', req.authMode);
+  }
   next();
 }
 
@@ -47,4 +70,4 @@ function requirePermission(permission) {
   };
 }
 
-module.exports = { authMiddleware, requirePermission, TOKEN_MAP };
+module.exports = { authMiddleware, requirePermission, TOKEN_MAP, extractBearerToken };

--- a/Mobile/backend/middleware/envelope.js
+++ b/Mobile/backend/middleware/envelope.js
@@ -1,9 +1,7 @@
-const { v4: uuidv4 } = require('crypto');
-
 /**
  * Generate a simple request ID
  */
-function requestId() {
+function requestIdFallback() {
   const ts = Date.now().toString(36);
   const rand = Math.random().toString(36).slice(2, 8);
   return `req_${ts}_${rand}`;
@@ -12,11 +10,11 @@ function requestId() {
 /**
  * Success envelope: { code: "OK", message, requestId, data }
  */
-function ok(data, message = 'success') {
+function ok(data, message = 'success', requestId = requestIdFallback()) {
   return {
     code: 'OK',
     message,
-    requestId: requestId(),
+    requestId,
     data,
   };
 }
@@ -24,11 +22,11 @@ function ok(data, message = 'success') {
 /**
  * Error envelope: { code, message, requestId }
  */
-function fail(code, message, status) {
+function fail(code, message, requestId = requestIdFallback()) {
   return {
     code,
     message,
-    requestId: requestId(),
+    requestId,
   };
 }
 
@@ -36,9 +34,10 @@ function fail(code, message, status) {
  * Middleware to attach envelope helpers to res
  */
 function envelopeMiddleware(req, res, next) {
-  res.ok = (data, message) => res.json(ok(data, message));
-  res.fail = (status, code, message) => res.status(status).json(fail(code, message));
+  res.ok = (data, message) => res.json(ok(data, message, req.requestId));
+  res.fail = (status, code, message) =>
+    res.status(status).json(fail(code, message, req.requestId));
   next();
 }
 
-module.exports = { envelopeMiddleware, ok, fail, requestId };
+module.exports = { envelopeMiddleware, ok, fail, requestIdFallback };

--- a/Mobile/backend/middleware/requestContext.js
+++ b/Mobile/backend/middleware/requestContext.js
@@ -1,0 +1,19 @@
+function createRequestId() {
+  const ts = Date.now().toString(36);
+  const rand = Math.random().toString(36).slice(2, 8);
+  return `req_${ts}_${rand}`;
+}
+
+function requestContext(runtimeConfig) {
+  return (req, res, next) => {
+    req.requestId = req.headers['x-request-id'] || createRequestId();
+    req.apiVersion = req.path.startsWith('/api/v1') ? 'v1' : 'legacy';
+    res.setHeader('X-Request-Id', req.requestId);
+    if (runtimeConfig.exposeDebugHeaders) {
+      res.setHeader('X-Api-Version', req.apiVersion);
+    }
+    next();
+  };
+}
+
+module.exports = { requestContext, createRequestId };

--- a/Mobile/backend/package.json
+++ b/Mobile/backend/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "dev": "node --watch server.js",
-    "test": "node test/geo.test.js && node test/fenceStore.test.js"
+    "test": "node --test test/*.test.js"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/Mobile/backend/routes/alerts.js
+++ b/Mobile/backend/routes/alerts.js
@@ -8,10 +8,16 @@ const router = Router();
 let alerts = seedAlerts.map((a) => ({ ...a }));
 
 const VALID_STAGES = ['pending', 'acknowledged', 'handled', 'archived'];
+const VALID_BATCH_ACTIONS = ['ack', 'handle', 'archive'];
 const STAGE_TRANSITIONS = {
   pending: 'acknowledged',
   acknowledged: 'handled',
   handled: 'archived',
+};
+const ACTION_TARGET_STAGE = {
+  ack: 'acknowledged',
+  handle: 'handled',
+  archive: 'archived',
 };
 
 /**
@@ -87,8 +93,8 @@ router.post(
     if (!Array.isArray(alertIds) || !alertIds.length) {
       return res.fail(422, 'VALIDATION_ERROR', 'alertIds 必须为非空数组');
     }
-    if (!VALID_STAGES.includes(action)) {
-      return res.fail(422, 'VALIDATION_ERROR', `action 必须为 ${VALID_STAGES.join(' / ')}`);
+    if (!VALID_BATCH_ACTIONS.includes(action)) {
+      return res.fail(422, 'VALIDATION_ERROR', `action 必须为 ${VALID_BATCH_ACTIONS.join(' / ')}`);
     }
 
     const updated = [];
@@ -101,15 +107,7 @@ router.post(
         continue;
       }
       const expected = STAGE_TRANSITIONS[alert.stage];
-      if (action === 'ack' && expected !== 'acknowledged') {
-        errors.push({ id, error: 'INVALID_TRANSITION', currentStage: alert.stage });
-        continue;
-      }
-      if (action === 'handle' && expected !== 'handled') {
-        errors.push({ id, error: 'INVALID_TRANSITION', currentStage: alert.stage });
-        continue;
-      }
-      if (action === 'archive' && expected !== 'archived') {
+      if (expected !== ACTION_TARGET_STAGE[action]) {
         errors.push({ id, error: 'INVALID_TRANSITION', currentStage: alert.stage });
         continue;
       }

--- a/Mobile/backend/routes/auth.js
+++ b/Mobile/backend/routes/auth.js
@@ -1,19 +1,73 @@
 const { Router } = require('express');
 const { users } = require('../data/seed');
+const {
+  issueTokenPair,
+  verifyAccessToken,
+  refreshTokenPair,
+  revokeRefreshToken,
+} = require('../services/mockTokenService');
 
 const router = Router();
 
-/**
- * POST /api/auth/login
- * Body: { role: "owner" | "worker" | "ops" }
- */
+function resolveRole(body = {}) {
+  if (body.role && users[body.role]) return body.role;
+  const account = typeof body.account === 'string' ? body.account.trim().toLowerCase() : '';
+  if (users[account]) return account;
+  return Object.values(users).find((user) =>
+    [user.userId, user.mobile, user.name].filter(Boolean).some((value) =>
+      String(value).toLowerCase() === account
+    )
+  )?.role || null;
+}
+
+function publicUser(user) {
+  const { userId, tenantId, name, role, mobile, permissions } = user;
+  return { userId, tenantId, name, role, mobile, permissions };
+}
+
 router.post('/login', (req, res) => {
-  const { role } = req.body || {};
-  if (!role || !users[role]) {
-    return res.fail(422, 'VALIDATION_ERROR', 'role 必须为 owner / worker / ops');
+  const role = resolveRole(req.body);
+  if (!role) {
+    return res.fail(422, 'VALIDATION_ERROR', 'role 或 account 必须映射到 owner / worker / ops');
   }
-  const token = `mock-token-${role}`;
-  res.ok({ token, role });
+  const tokens = issueTokenPair(role);
+  const user = publicUser(users[role]);
+  res.ok({
+    token: tokens.accessToken,
+    role,
+    accessToken: tokens.accessToken,
+    refreshToken: tokens.refreshToken,
+    expiresAt: tokens.expiresAt,
+    user,
+  });
+});
+
+router.post('/refresh', (req, res) => {
+  const { refreshToken } = req.body || {};
+  if (!refreshToken) {
+    return res.fail(422, 'VALIDATION_ERROR', 'refreshToken 必填');
+  }
+  const tokens = refreshTokenPair(refreshToken);
+  if (!tokens) {
+    return res.fail(401, 'AUTH_UNAUTHORIZED', 'refreshToken 无效或已过期');
+  }
+  const user = publicUser(verifyAccessToken(tokens.accessToken));
+  res.ok({
+    token: tokens.accessToken,
+    role: user.role,
+    accessToken: tokens.accessToken,
+    refreshToken: tokens.refreshToken,
+    expiresAt: tokens.expiresAt,
+    user,
+  });
+});
+
+router.post('/logout', (req, res) => {
+  const { refreshToken } = req.body || {};
+  if (refreshToken) {
+    revokeRefreshToken(refreshToken);
+  }
+  res.ok({ success: true });
 });
 
 module.exports = router;

--- a/Mobile/backend/routes/me.js
+++ b/Mobile/backend/routes/me.js
@@ -1,5 +1,6 @@
 const { Router } = require('express');
 const { authMiddleware } = require('../middleware/auth');
+const { buildUserProjection } = require('../services/userProjectionService');
 
 const router = Router();
 
@@ -7,8 +8,7 @@ const router = Router();
  * GET /api/me
  */
 router.get('/', authMiddleware, (req, res) => {
-  const { userId, tenantId, name, role, permissions } = req.user;
-  res.ok({ userId, tenantId, name, role, permissions });
+  res.ok(buildUserProjection(req.user));
 });
 
 module.exports = router;

--- a/Mobile/backend/routes/profile.js
+++ b/Mobile/backend/routes/profile.js
@@ -1,6 +1,6 @@
 const { Router } = require('express');
 const { authMiddleware, requirePermission } = require('../middleware/auth');
-const { tenants } = require('../data/seed');
+const { buildUserProjection } = require('../services/userProjectionService');
 
 const router = Router();
 
@@ -12,15 +12,7 @@ router.get(
   authMiddleware,
   requirePermission('profile:view'),
   (req, res) => {
-    const { userId, name, mobile, tenantId } = req.user;
-    const tenant = tenants.find((t) => t.id === tenantId);
-    res.ok({
-      userId,
-      name,
-      mobile,
-      tenantName: tenant ? tenant.name : null,
-      notificationEnabled: true,
-    });
+    res.ok(buildUserProjection(req.user));
   }
 );
 

--- a/Mobile/backend/routes/registerApiRoutes.js
+++ b/Mobile/backend/routes/registerApiRoutes.js
@@ -1,0 +1,25 @@
+const authRoutes = require('./auth');
+const meRoutes = require('./me');
+const dashboardRoutes = require('./dashboard');
+const mapRoutes = require('./map');
+const alertsRoutes = require('./alerts');
+const fencesRoutes = require('./fences');
+const tenantsRoutes = require('./tenants');
+const profileRoutes = require('./profile');
+const twinRoutes = require('./twin');
+const devicesRoutes = require('./devices');
+
+function registerApiRoutes(app, prefix) {
+  app.use(`${prefix}/auth`, authRoutes);
+  app.use(`${prefix}/me`, meRoutes);
+  app.use(`${prefix}/dashboard`, dashboardRoutes);
+  app.use(`${prefix}/map`, mapRoutes);
+  app.use(`${prefix}/alerts`, alertsRoutes);
+  app.use(`${prefix}/fences`, fencesRoutes);
+  app.use(`${prefix}/tenants`, tenantsRoutes);
+  app.use(`${prefix}/profile`, profileRoutes);
+  app.use(`${prefix}/twin`, twinRoutes);
+  app.use(`${prefix}/devices`, devicesRoutes);
+}
+
+module.exports = { registerApiRoutes };

--- a/Mobile/backend/server.js
+++ b/Mobile/backend/server.js
@@ -1,38 +1,24 @@
 const express = require('express');
 const cors = require('cors');
 
+const { buildRuntimeConfig } = require('./config/runtimeConfig');
 const { envelopeMiddleware } = require('./middleware/envelope');
-
-const authRoutes = require('./routes/auth');
-const meRoutes = require('./routes/me');
-const dashboardRoutes = require('./routes/dashboard');
-const mapRoutes = require('./routes/map');
-const alertsRoutes = require('./routes/alerts');
-const fencesRoutes = require('./routes/fences');
-const tenantsRoutes = require('./routes/tenants');
-const profileRoutes = require('./routes/profile');
-const twinRoutes = require('./routes/twin');
-const devicesRoutes = require('./routes/devices');
+const { requestContext } = require('./middleware/requestContext');
+const { registerApiRoutes } = require('./routes/registerApiRoutes');
 
 const app = express();
 const PORT = 3001;
+const runtimeConfig = buildRuntimeConfig();
 
 // Middleware
 app.use(cors());
 app.use(express.json());
+app.use(requestContext(runtimeConfig));
 app.use(envelopeMiddleware);
 
 // Routes
-app.use('/api/auth', authRoutes);
-app.use('/api/me', meRoutes);
-app.use('/api/dashboard', dashboardRoutes);
-app.use('/api/map', mapRoutes);
-app.use('/api/alerts', alertsRoutes);
-app.use('/api/fences', fencesRoutes);
-app.use('/api/tenants', tenantsRoutes);
-app.use('/api/profile', profileRoutes);
-app.use('/api/twin', twinRoutes);
-app.use('/api/devices', devicesRoutes);
+registerApiRoutes(app, '/api');
+registerApiRoutes(app, '/api/v1');
 
 // 404 fallback
 app.use((req, res) => {
@@ -40,47 +26,55 @@ app.use((req, res) => {
 });
 
 // Known routes (printed at startup for convenience)
-const ROUTE_TABLE = [
-  ['POST',   '/api/auth/login'],
-  ['GET',    '/api/me'],
-  ['GET',    '/api/dashboard/summary'],
-  ['GET',    '/api/map/trajectories'],
-  ['GET',    '/api/alerts'],
-  ['POST',   '/api/alerts/:id/ack'],
-  ['POST',   '/api/alerts/:id/handle'],
-  ['POST',   '/api/alerts/:id/archive'],
-  ['POST',   '/api/alerts/batch-handle'],
-  ['GET',    '/api/fences'],
-  ['GET',    '/api/fences/:id'],
-  ['POST',   '/api/fences'],
-  ['PUT',    '/api/fences/:id'],
-  ['DELETE', '/api/fences/:id'],
-  ['GET',    '/api/tenants'],
-  ['GET',    '/api/tenants/:id'],
-  ['POST',   '/api/tenants'],
-  ['PUT',    '/api/tenants/:id'],
-  ['DELETE', '/api/tenants/:id'],
-  ['POST',   '/api/tenants/:id/status'],
-  ['POST',   '/api/tenants/:id/license'],
-  ['GET',    '/api/profile'],
-  ['GET',    '/api/twin/overview'],
-  ['GET',    '/api/twin/fever/list'],
-  ['GET',    '/api/twin/fever/:id'],
-  ['GET',    '/api/twin/digestive/list'],
-  ['GET',    '/api/twin/digestive/:id'],
-  ['GET',    '/api/twin/estrus/list'],
-  ['GET',    '/api/twin/estrus/:id'],
-  ['GET',    '/api/twin/epidemic/summary'],
-  ['GET',    '/api/twin/epidemic/contacts'],
-  ['GET',    '/api/devices'],
+const API_PREFIXES = ['/api', '/api/v1'];
+const ROUTE_DEFINITIONS = [
+  ['POST',   '/auth/login'],
+  ['GET',    '/me'],
+  ['GET',    '/dashboard/summary'],
+  ['GET',    '/map/trajectories'],
+  ['GET',    '/alerts'],
+  ['POST',   '/alerts/:id/ack'],
+  ['POST',   '/alerts/:id/handle'],
+  ['POST',   '/alerts/:id/archive'],
+  ['POST',   '/alerts/batch-handle'],
+  ['GET',    '/fences'],
+  ['GET',    '/fences/:id'],
+  ['POST',   '/fences'],
+  ['PUT',    '/fences/:id'],
+  ['DELETE', '/fences/:id'],
+  ['GET',    '/tenants'],
+  ['GET',    '/tenants/:id'],
+  ['POST',   '/tenants'],
+  ['PUT',    '/tenants/:id'],
+  ['DELETE', '/tenants/:id'],
+  ['POST',   '/tenants/:id/status'],
+  ['POST',   '/tenants/:id/license'],
+  ['GET',    '/profile'],
+  ['GET',    '/twin/overview'],
+  ['GET',    '/twin/fever/list'],
+  ['GET',    '/twin/fever/:id'],
+  ['GET',    '/twin/digestive/list'],
+  ['GET',    '/twin/digestive/:id'],
+  ['GET',    '/twin/estrus/list'],
+  ['GET',    '/twin/estrus/:id'],
+  ['GET',    '/twin/epidemic/summary'],
+  ['GET',    '/twin/epidemic/contacts'],
+  ['GET',    '/devices'],
 ];
+const ROUTE_TABLE = API_PREFIXES.flatMap((prefix) =>
+  ROUTE_DEFINITIONS.map(([method, path]) => [method, `${prefix}${path}`])
+);
 
 // Start server
-app.listen(PORT, () => {
-  console.log(`\n  Mock API Server running at http://localhost:${PORT}\n`);
-  console.log('  Registered routes:');
-  ROUTE_TABLE.forEach(([method, path]) =>
-    console.log(`  ${method.padEnd(7)} ${path}`)
-  );
-  console.log('');
-});
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`\n  Mock API Server running at http://localhost:${PORT}\n`);
+    console.log('  Registered routes:');
+    ROUTE_TABLE.forEach(([method, path]) =>
+      console.log(`  ${method.padEnd(7)} ${path}`)
+    );
+    console.log('');
+  });
+}
+
+module.exports = { app };

--- a/Mobile/backend/services/mockTokenService.js
+++ b/Mobile/backend/services/mockTokenService.js
@@ -1,0 +1,65 @@
+const crypto = require('node:crypto');
+const { users } = require('../data/seed');
+
+const refreshTokens = new Map();
+
+function base64UrlJson(value) {
+  return Buffer.from(JSON.stringify(value)).toString('base64url');
+}
+
+function issueAccessToken(role) {
+  const user = users[role];
+  if (!user) return null;
+  const header = base64UrlJson({ alg: 'mock', typ: 'JWT' });
+  const payload = base64UrlJson({
+    userId: user.userId,
+    tenantId: user.tenantId,
+    role: user.role,
+    permissions: user.permissions,
+    exp: Math.floor(Date.now() / 1000) + 3600,
+    jti: crypto.randomUUID(),
+  });
+  return `${header}.${payload}.mock-signature`;
+}
+
+function verifyAccessToken(token) {
+  const parts = token.split('.');
+  if (parts.length !== 3 || parts[2] !== 'mock-signature') return null;
+  try {
+    const payload = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'));
+    if (!payload.exp || payload.exp < Math.floor(Date.now() / 1000)) return null;
+    return users[payload.role] || null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function issueTokenPair(role) {
+  const accessToken = issueAccessToken(role);
+  if (!accessToken) return null;
+  const refreshToken = crypto.randomUUID();
+  refreshTokens.set(refreshToken, { role, expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000 });
+  return {
+    accessToken,
+    refreshToken,
+    expiresAt: new Date(Date.now() + 3600 * 1000).toISOString(),
+  };
+}
+
+function refreshTokenPair(refreshToken) {
+  const record = refreshTokens.get(refreshToken);
+  if (!record || record.expiresAt < Date.now()) return null;
+  refreshTokens.delete(refreshToken);
+  return issueTokenPair(record.role);
+}
+
+function revokeRefreshToken(refreshToken) {
+  refreshTokens.delete(refreshToken);
+}
+
+module.exports = {
+  issueTokenPair,
+  verifyAccessToken,
+  refreshTokenPair,
+  revokeRefreshToken,
+};

--- a/Mobile/backend/services/userProjectionService.js
+++ b/Mobile/backend/services/userProjectionService.js
@@ -1,0 +1,17 @@
+const { tenants } = require('../data/seed');
+
+function buildUserProjection(user) {
+  const tenant = tenants.find((item) => item.id === user.tenantId);
+  return {
+    userId: user.userId,
+    tenantId: user.tenantId,
+    name: user.name,
+    role: user.role,
+    mobile: user.mobile,
+    permissions: user.permissions,
+    tenantName: tenant ? tenant.name : null,
+    notificationEnabled: true,
+  };
+}
+
+module.exports = { buildUserProjection };

--- a/Mobile/backend/test/apiVersionRoutes.test.js
+++ b/Mobile/backend/test/apiVersionRoutes.test.js
@@ -1,0 +1,240 @@
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+
+process.env.EXPOSE_API_DEBUG_HEADERS = 'true';
+
+const { app } = require('../server');
+
+async function request(path, headers = {}) {
+  const server = app.listen(0);
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}${path}`, { headers });
+    return {
+      status: response.status,
+      headers: response.headers,
+      body: await response.json(),
+    };
+  } finally {
+    server.close();
+  }
+}
+
+async function jsonRequest(path, options = {}) {
+  const server = app.listen(0);
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}${path}`, options);
+    return {
+      status: response.status,
+      headers: response.headers,
+      body: await response.json(),
+    };
+  } finally {
+    server.close();
+  }
+}
+
+function mockHeaders(role = 'owner') {
+  process.env.ENABLE_MOCK_TOKEN = 'true';
+  process.env.MOCK_TOKEN_ALLOWED_ENVS = 'development,dev,staging';
+  return { Authorization: `Bearer mock-token-${role}` };
+}
+
+test('request context forwards X-Request-Id into response envelope', async () => {
+  const response = await request('/api/me', {
+    ...mockHeaders('owner'),
+    'X-Request-Id': 'req-test-001',
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal(response.headers.get('x-request-id'), 'req-test-001');
+  assert.equal(response.body.requestId, 'req-test-001');
+});
+
+test('request context reports legacy and v1 api version debug headers', async () => {
+  const headers = mockHeaders('owner');
+  const legacy = await request('/api/me', headers);
+  const v1 = await request('/api/v1/me', headers);
+
+  assert.equal(legacy.headers.get('x-api-version'), 'legacy');
+  assert.equal(v1.headers.get('x-api-version'), 'v1');
+});
+
+test('auth login route equivalence covers legacy and v1 prefixes', async () => {
+  const body = JSON.stringify({ role: 'owner' });
+  const legacy = await jsonRequest('/api/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+  });
+  const v1 = await jsonRequest('/api/v1/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+  });
+
+  assert.equal(legacy.status, v1.status);
+  assert.equal(legacy.body.code, v1.body.code);
+  assert.equal(legacy.body.data.role, v1.body.data.role);
+  assert.equal(typeof legacy.body.data.token, 'string');
+  assert.equal(typeof v1.body.data.token, 'string');
+});
+
+test('/api and /api/v1 return equivalent /me data', async () => {
+  const headers = mockHeaders('owner');
+  const legacy = await request('/api/me', headers);
+  const v1 = await request('/api/v1/me', headers);
+
+  assert.equal(legacy.status, 200);
+  assert.equal(v1.status, 200);
+  assert.equal(legacy.body.code, 'OK');
+  assert.equal(v1.body.code, 'OK');
+  assert.equal(legacy.body.data.userId, v1.body.data.userId);
+  assert.equal(legacy.body.data.role, v1.body.data.role);
+});
+
+test('/me includes profile fields used by Flutter', async () => {
+  const headers = mockHeaders('owner');
+  const response = await request('/api/v1/me', {
+    Authorization: headers.Authorization,
+  });
+
+  assert.equal(response.status, 200);
+  assert.equal(response.body.data.tenantName, '华东示范牧场');
+  assert.equal(response.body.data.notificationEnabled, true);
+});
+
+test('/profile and /me use compatible user projection', async () => {
+  const headers = mockHeaders('owner');
+  const me = await request('/api/v1/me', headers);
+  const profile = await request('/api/v1/profile', headers);
+
+  assert.equal(profile.body.data.userId, me.body.data.userId);
+  assert.equal(profile.body.data.tenantName, me.body.data.tenantName);
+});
+
+test('core route equivalence covers GET tenants, fences, and alerts', async () => {
+  const headers = mockHeaders('owner');
+  const cases = [
+    ['/tenants?pageSize=20'],
+    ['/fences?pageSize=20'],
+    ['/alerts?pageSize=20'],
+  ];
+
+  for (const [path] of cases) {
+    const legacy = await request(`/api${path}`, headers);
+    const v1 = await request(`/api/v1${path}`, headers);
+    assert.equal(legacy.status, v1.status);
+    assert.equal(legacy.body.code, v1.body.code);
+  }
+});
+
+test('core route equivalence covers tenant and fence POST validation', async () => {
+  const headers = { ...mockHeaders('owner'), 'Content-Type': 'application/json' };
+  const cases = [
+    ['/tenants', { name: '', licenseTotal: 100 }],
+    ['/fences', { name: '', type: 'polygon', coordinates: [], alarmEnabled: true }],
+  ];
+
+  for (const [path, body] of cases) {
+    const legacy = await jsonRequest(`/api${path}`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    });
+    const v1 = await jsonRequest(`/api/v1${path}`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    });
+    assert.equal(legacy.status, v1.status);
+    assert.equal(legacy.body.code, v1.body.code);
+  }
+});
+
+test('core route equivalence covers alert ack and batch validation', async () => {
+  const headers = { ...mockHeaders('owner'), 'Content-Type': 'application/json' };
+  const cases = [
+    ['/alerts/does-not-exist/ack', {}],
+    ['/alerts/batch-handle', { alertIds: [], action: 'ack' }],
+  ];
+
+  for (const [path, body] of cases) {
+    const legacy = await jsonRequest(`/api${path}`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    });
+    const v1 = await jsonRequest(`/api/v1${path}`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    });
+    assert.equal(legacy.status, v1.status);
+    assert.equal(legacy.body.code, v1.body.code);
+  }
+});
+
+test('batch-handle accepts action ack', async () => {
+  const headers = mockHeaders('owner');
+  const server = app.listen(0);
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/v1/alerts/batch-handle`, {
+      method: 'POST',
+      headers: {
+        Authorization: headers.Authorization,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ alertIds: ['alert-001'], action: 'ack' }),
+    });
+    const body = await response.json();
+    assert.equal(response.status, 200);
+    assert.equal(body.code, 'OK');
+  } finally {
+    server.close();
+  }
+});
+
+test('batch-handle returns errors for invalid transitions without updating alert', async () => {
+  const headers = { ...mockHeaders('owner'), 'Content-Type': 'application/json' };
+  const invalidAck = await jsonRequest('/api/v1/alerts/batch-handle', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ alertIds: ['alert-002'], action: 'ack' }),
+  });
+  const validHandle = await jsonRequest('/api/v1/alerts/alert-002/handle', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({}),
+  });
+
+  assert.equal(invalidAck.status, 200);
+  assert.equal(invalidAck.body.code, 'OK');
+  assert.deepEqual(invalidAck.body.data.errors, [
+    { id: 'alert-002', error: 'INVALID_TRANSITION', currentStage: 'acknowledged' },
+  ]);
+  assert.equal(validHandle.status, 200);
+  assert.equal(validHandle.body.code, 'OK');
+  assert.equal(validHandle.body.data.stage, 'handled');
+});
+
+test('batch-handle success remains equivalent across legacy and v1 routes', async () => {
+  const headers = { ...mockHeaders('owner'), 'Content-Type': 'application/json' };
+  const legacy = await jsonRequest('/api/alerts/batch-handle', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ alertIds: ['alert-005'], action: 'ack' }),
+  });
+  const v1 = await jsonRequest('/api/v1/alerts/batch-handle', {
+    method: 'POST',
+    headers,
+    body: JSON.stringify({ alertIds: ['alert-006'], action: 'ack' }),
+  });
+
+  assert.equal(legacy.status, v1.status);
+  assert.equal(legacy.body.code, v1.body.code);
+  assert.equal(legacy.body.data.updated, v1.body.data.updated);
+  assert.deepEqual(legacy.body.data.errors, v1.body.data.errors);
+});

--- a/Mobile/backend/test/authChain.test.js
+++ b/Mobile/backend/test/authChain.test.js
@@ -1,0 +1,162 @@
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+const { buildRuntimeConfig } = require('../config/runtimeConfig');
+const { issueTokenPair } = require('../services/mockTokenService');
+const { app } = require('../server');
+
+const ENV_KEYS = [
+  'ENABLE_MOCK_TOKEN',
+  'MOCK_TOKEN_ALLOWED_ENVS',
+  'MOCK_TOKEN_BREAK_GLASS',
+  'MOCK_TOKEN_BREAK_GLASS_EXPIRES_AT',
+  'NODE_ENV',
+];
+
+function snapshotEnv() {
+  return Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+}
+
+function restoreEnv(snapshot) {
+  for (const key of ENV_KEYS) {
+    if (snapshot[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = snapshot[key];
+    }
+  }
+}
+
+async function getMe(token) {
+  const server = app.listen(0);
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/v1/me`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return { status: response.status, body: await response.json(), headers: response.headers };
+  } finally {
+    server.close();
+  }
+}
+
+async function postJson(path, body) {
+  const server = app.listen(0);
+  try {
+    const { port } = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}${path}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    return { status: response.status, body: await response.json(), headers: response.headers };
+  } finally {
+    server.close();
+  }
+}
+
+test('runtimeConfig disables mock-token by default', () => {
+  const config = buildRuntimeConfig({});
+  assert.equal(config.enableMockToken, false);
+});
+
+test('runtimeConfig rejects production mock-token without break-glass', () => {
+  assert.throws(
+    () => buildRuntimeConfig({
+      NODE_ENV: 'production',
+      ENABLE_MOCK_TOKEN: 'true',
+      MOCK_TOKEN_ALLOWED_ENVS: 'production',
+    }),
+    /mock-token cannot be enabled in production/,
+  );
+});
+
+test('runtimeConfig allows unexpired production break-glass', () => {
+  const config = buildRuntimeConfig({
+    NODE_ENV: 'production',
+    ENABLE_MOCK_TOKEN: 'true',
+    MOCK_TOKEN_ALLOWED_ENVS: 'production',
+    MOCK_TOKEN_BREAK_GLASS: 'true',
+    MOCK_TOKEN_BREAK_GLASS_EXPIRES_AT: '2999-01-01T00:00:00.000Z',
+  });
+  assert.equal(config.enableMockToken, true);
+});
+
+test('auth chain accepts mock JWT access token first', async () => {
+  const { accessToken } = issueTokenPair('owner');
+  const response = await getMe(accessToken);
+  assert.equal(response.status, 200);
+  assert.equal(response.body.data.role, 'owner');
+  assert.equal(response.headers.get('x-auth-mode'), 'jwt');
+});
+
+test('mock-token is rejected when fallback is disabled', async () => {
+  const env = snapshotEnv();
+  try {
+    delete process.env.ENABLE_MOCK_TOKEN;
+    delete process.env.MOCK_TOKEN_ALLOWED_ENVS;
+    const response = await getMe('mock-token-owner');
+    assert.equal(response.status, 401);
+    assert.equal(response.body.code, 'AUTH_UNAUTHORIZED');
+  } finally {
+    restoreEnv(env);
+  }
+});
+
+test('mock-token is accepted when fallback is explicitly enabled', async () => {
+  const env = snapshotEnv();
+  try {
+    process.env.ENABLE_MOCK_TOKEN = 'true';
+    process.env.MOCK_TOKEN_ALLOWED_ENVS = 'development,dev,staging';
+    process.env.NODE_ENV = 'development';
+    const response = await getMe('mock-token-owner');
+    assert.equal(response.status, 200);
+    assert.equal(response.body.data.role, 'owner');
+    assert.equal(response.headers.get('x-auth-mode'), 'mock');
+  } finally {
+    restoreEnv(env);
+  }
+});
+
+test('login accepts account/password mock shape and returns token pair', async () => {
+  const response = await postJson('/api/v1/auth/login', {
+    account: 'worker',
+    password: 'mock-password',
+  });
+  assert.equal(response.status, 200);
+  assert.equal(response.body.data.role, 'worker');
+  assert.equal(response.body.data.token, response.body.data.accessToken);
+  assert.equal(typeof response.body.data.refreshToken, 'string');
+  assert.equal(response.body.data.user.role, 'worker');
+
+  const me = await getMe(response.body.data.accessToken);
+  assert.equal(me.status, 200);
+  assert.equal(me.body.data.role, 'worker');
+});
+
+test('refresh rotates token pair and logout revokes refresh token', async () => {
+  const login = await postJson('/api/v1/auth/login', { role: 'owner' });
+  const refresh = await postJson('/api/v1/auth/refresh', {
+    refreshToken: login.body.data.refreshToken,
+  });
+
+  assert.equal(refresh.status, 200);
+  assert.equal(refresh.body.data.role, 'owner');
+  assert.notEqual(refresh.body.data.refreshToken, login.body.data.refreshToken);
+
+  const reused = await postJson('/api/v1/auth/refresh', {
+    refreshToken: login.body.data.refreshToken,
+  });
+  assert.equal(reused.status, 401);
+  assert.equal(reused.body.code, 'AUTH_UNAUTHORIZED');
+
+  const logout = await postJson('/api/v1/auth/logout', {
+    refreshToken: refresh.body.data.refreshToken,
+  });
+  assert.equal(logout.status, 200);
+
+  const revoked = await postJson('/api/v1/auth/refresh', {
+    refreshToken: refresh.body.data.refreshToken,
+  });
+  assert.equal(revoked.status, 401);
+  assert.equal(revoked.body.code, 'AUTH_UNAUTHORIZED');
+});

--- a/Mobile/docs/api-contracts/2026-04-21-backend-api-contract.md
+++ b/Mobile/docs/api-contracts/2026-04-21-backend-api-contract.md
@@ -1,0 +1,712 @@
+# 后端 API 契约（基于 mobile_app 现状反向梳理）
+
+## 0. 文档说明
+
+- **目标**：以 `Mobile/mobile_app` 当前代码为真实依据，统一梳理 App 已调用 / 将调用的所有后端接口，固化字段与行为契约。
+- **区别于**：`mobile-app-mock-api-contract.md` 为早期 Mock 先行版本，本文档为**代码落地后**的修订版，包含新增端点（孪生、设备、牲畜详情、统计）与实际字段差异。
+- **真实来源**：`Mobile/mobile_app/lib/core/api/api_cache.dart`、各 `features/*/data/live_*.dart`、`Mobile/backend/routes/*.js`、`Mobile/backend/data/*.js`。
+- **覆盖版本**：Phase 1（MVP 可联调） + Phase 2（扩展字段与端点）标注。
+
+---
+
+## 1. 全局约定
+
+### 1.1 Base URL
+
+| 形态 | URL |
+|------|-----|
+| 开发（Web） | `http://127.0.0.1:3001/api` |
+| 开发（Native） | `http://localhost:3001/api` |
+| 编译期覆盖 | `--dart-define=API_BASE_URL=<url>` |
+
+所有路径均以 `/api` 开头；文档接下来只写 `/api` 之后的部分。
+
+新后端迁移后 `/api/v1` 是规范契约源；`/api` 长期保留为兼容入口。兼容承诺见 `api-compatibility-matrix.md`。
+
+### 1.2 响应包络
+
+**成功**：
+
+```json
+{
+  "code": "OK",
+  "message": "success",
+  "requestId": "req_xxx",
+  "data": {}
+}
+```
+
+**失败**：
+
+```json
+{
+  "code": "VALIDATION_ERROR",
+  "message": "name is required",
+  "requestId": "req_xxx"
+}
+```
+
+- `code` 为业务语义码（见 §1.6），HTTP 状态码与之对应。
+- 失败响应**不包含 `data` 字段**；前端以 `code` 判断，不依赖 HTTP 状态文本。
+- `requestId` 由服务端生成并在响应头 `X-Request-Id` 中也可回传（Phase 2 强制）。
+
+### 1.3 分页结构
+
+列表型 `data`：
+
+```json
+{
+  "items": [],
+  "page": 1,
+  "pageSize": 20,
+  "total": 0
+}
+```
+
+- 默认 `page=1`，`pageSize=20`；最大 `pageSize=200`。
+- App 预加载阶段使用 `pageSize=100/200` 拉大页（见 §2.2），后续收敛为服务端分页。
+
+### 1.4 时间与 ID
+
+| 项 | 约定 |
+|----|------|
+| 时间 | ISO-8601 带时区，优先 `+08:00`（示例：`2026-04-21T10:20:00+08:00`） |
+| 租户 ID | `tenant_{n}`，`n` 为数字（当前 seed：`tenant_001` … `tenant_006`） |
+| 用户 ID | `user_{role}` / `user_{n}` |
+| 动物 ID | `animal_{nnn}`；耳标 `SL-2024-{nnn}` |
+| 设备 ID | `dev_{type}_{nnn}`（示例：`dev_gps_001`） |
+| 告警 ID | `alert_{nnn}`（**注意**：当前 seed 使用 `alert-001` 连字符风格，联调前需统一为下划线） |
+| 围栏 ID | `fence_{nnn}` |
+
+### 1.5 鉴权
+
+- Header：`Authorization: Bearer <token>`。
+- **当前 Mock Token**：`mock-token-owner` / `mock-token-worker` / `mock-token-ops`。
+- **Phase 2 升级**：改为真实 JWT（见基础设施文档）；本契约保持 Bearer 机制不变，仅替换 token 生成与校验实现。
+- 除 `POST /auth/login` 外，所有接口都必须带 Authorization Header。
+
+### 1.6 错误码清单
+
+| code | HTTP | 含义 |
+|------|------|------|
+| `AUTH_UNAUTHORIZED` | 401 | 未登录或 Token 失效 |
+| `AUTH_FORBIDDEN` | 403 | 已登录但无权限 |
+| `TENANT_DISABLED` | 403 | 租户已禁用 |
+| `RESOURCE_NOT_FOUND` | 404 | 资源不存在 |
+| `CONFLICT` | 409 | 状态/并发冲突（如告警状态机迁移冲突、围栏更新版本冲突） |
+| `VALIDATION_ERROR` | 422 | 参数校验失败 |
+| `RATE_LIMITED` | 429 | 超过限流（Phase 2） |
+| `INTERNAL_ERROR` | 500 | 服务内部异常 |
+| `UPSTREAM_UNAVAILABLE` | 503 | 上游（GPS、AI）不可用 |
+
+### 1.7 权限码
+
+| permission | 说明 | 默认持有角色 |
+|------------|------|--------------|
+| `dashboard:view` | 看板 | owner / worker |
+| `map:view` | 地图与轨迹 | owner / worker |
+| `alert:view` / `:ack` / `:handle` / `:archive` / `:batch` | 告警分级 | owner（全部）/ worker（view + ack） |
+| `fence:view` / `:manage` | 围栏查看 / 增删改 | owner / worker |
+| `livestock:view` / `:edit` | 牲畜信息 | owner / worker |
+| `device:view` / `:manage` | 设备 | owner |
+| `twin:view` | 数字孪生 | owner |
+| `stats:view` | 统计 | owner |
+| `tenant:view` / `:create` / `:edit` / `:toggle` / `:delete` | 租户管理 | ops |
+| `license:manage` | License 配额 | ops |
+| `profile:view` | 我的 | 全部 |
+
+---
+
+## 2. 预加载与缓存
+
+### 2.1 ApiCache 启动预加载
+
+`APP_MODE=live` 时，App 在启动阶段通过 `ApiCache.init(role)` **并行**请求以下端点，失败任一不阻塞启动：
+
+1. `GET /dashboard/summary`
+2. `GET /map/trajectories?animalId=animal_001&range=24h`
+3. `GET /alerts?pageSize=100`
+4. `GET /fences?pageSize=100`
+5. `GET /tenants?pageSize=100`
+6. `GET /profile`
+7. `GET /twin/overview`
+8. `GET /twin/fever/list`
+9. `GET /twin/digestive/list`
+10. `GET /twin/estrus/list`
+11. `GET /twin/epidemic/summary`
+12. `GET /twin/epidemic/contacts`
+13. `GET /devices?pageSize=200`
+
+**服务端要求**：以上端点必须在 1.5s 内响应，否则前端回退到 Mock Repository。
+
+### 2.2 写操作后强制刷新
+
+| 写操作 | 触发的刷新 GET |
+|--------|----------------|
+| 租户 CRUD / 状态 / License | `GET /tenants?pageSize=100` |
+| 围栏 CRUD | `GET /fences?pageSize=100` + `GET /map/trajectories` |
+| 告警状态迁移 | `GET /alerts?pageSize=100` |
+
+---
+
+## 3. 端点详述
+
+> 表格约定：
+> - ✅ 已实现、🟡 已实现但字段不齐 / 行为不符、🔴 未实现（需新建）、⚪ 已实现但 App 尚未对接。
+
+### 3.1 鉴权（`/auth`）
+
+| 状态 | Method | Path | 说明 |
+|------|--------|------|------|
+| ✅ | `POST` | `/auth/login` | 登录（Mock 仅按 role 签发 token） |
+
+**Request**：
+
+```json
+{ "role": "owner" }
+```
+
+**Response `data`**：
+
+```json
+{ "token": "mock-token-owner", "role": "owner" }
+```
+
+**Phase 2 升级**：入参改为 `{ account, password }` 或 OIDC 回调；响应增加 `expiresAt`、`refreshToken`。
+
+---
+
+### 3.2 当前用户（`/me`、`/profile`）
+
+| 状态 | Method | Path | 说明 |
+|------|--------|------|------|
+| ✅ | `GET` | `/me` | 返回当前 Token 关联用户 |
+| ✅ | `GET` | `/profile` | 我的页（与 `/me` 字段重叠，App 同时使用） |
+
+**`GET /me` Response `data`**：
+
+```json
+{
+  "userId": "user_owner",
+  "tenantId": "tenant_001",
+  "name": "牧场主-演示",
+  "role": "owner",
+  "permissions": ["dashboard:view", "..."]
+}
+```
+
+**`GET /profile` Response `data`**（App 使用字段）：
+
+```json
+{
+  "userId": "user_owner",
+  "name": "牧场主-演示",
+  "mobile": "138****0001",
+  "tenantName": "示例牧场",
+  "notificationEnabled": true
+}
+```
+
+**契约对齐项**：`/me` 与 `/profile` 应共享同一用户视图投影，`tenantName` 需在两者均返回；**Phase 2** 合并为单一 `/me` 端点并弃用 `/profile`。
+
+---
+
+### 3.3 看板（`/dashboard`）
+
+| 状态 | Method | Path | 说明 |
+|------|--------|------|------|
+| 🟡 | `GET` | `/dashboard/summary` | 看板指标 |
+
+**Response `data`**：
+
+```json
+{
+  "metrics": [
+    { "key": "alert-pending", "title": "待处理告警", "value": "12" },
+    { "key": "cattle-count",  "title": "在栏头数",   "value": "1,280" }
+  ],
+  "lastSyncAt": "2026-04-21T10:20:00+08:00"
+}
+```
+
+- `metrics[].key`：稳定字符串，前端拼为 `dashboard-metric-{key}` 作为 Widget Key。
+- `metrics[].value`：**字符串**（支持千分位、百分号等格式化）。
+- **对齐点**：`lastSyncAt` 当前 App 未使用但后端已返回，保留但标注可选。
+
+---
+
+### 3.4 地图与轨迹（`/map`）
+
+| 状态 | Method | Path | 说明 |
+|------|--------|------|------|
+| ✅ | `GET` | `/map/trajectories` | 牲畜轨迹 + 围栏 |
+
+**Query**：
+
+| 参数 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `animalId` | string | 否 | 默认首头 |
+| `range` | enum | 是 | `24h` / `7d` / `30d` |
+
+**Response `data`**：
+
+```json
+{
+  "animals": [
+    {
+      "id": "animal_001",
+      "earTag": "SL-2024-001",
+      "lat": 43.81,
+      "lng": 87.62,
+      "boundaryStatus": "inside"
+    }
+  ],
+  "selectedAnimalId": "animal_001",
+  "selectedRange": "24h",
+  "summaryText": "过去 24 小时采样 24 点",
+  "points": [
+    { "lat": 43.81, "lng": 87.62, "ts": "2026-04-21T09:00:00+08:00" }
+  ],
+  "fences": [ /* 围栏对象（见 3.6）*/ ],
+  "fallbackList": []
+}
+```
+
+- `boundaryStatus`：`inside` / `outside`（服务端判定后给出，避免前端再做几何运算）。
+- `points`：按小时/天降采样（由后端决定采样频率）。
+
+---
+
+### 3.5 告警（`/alerts`）
+
+| 状态 | Method | Path | 说明 |
+|------|--------|------|------|
+| ✅ | `GET` | `/alerts` | 列表（支持 stage 过滤、分页） |
+| ✅ | `POST` | `/alerts/:id/ack` | 确认 |
+| ✅ | `POST` | `/alerts/:id/handle` | 处理 |
+| ✅ | `POST` | `/alerts/:id/archive` | 归档 |
+| 🟡 | `POST` | `/alerts/batch-handle` | 批量（实现与契约不一致，见下） |
+
+**`GET /alerts` Query**：`stage`（`pending`/`acknowledged`/`handled`/`archived`）、`page`、`pageSize`。
+
+**`AlertItem` 字段**：
+
+```json
+{
+  "id": "alert_001",
+  "title": "耳标 SL-2024-017 体温异常",
+  "occurredAt": "2026-04-21T08:15:00+08:00",
+  "level": "critical",
+  "type": "health",
+  "stage": "pending",
+  "earTag": "SL-2024-017",
+  "livestockId": "1017"
+}
+```
+
+- `level`：`critical` → P0；`warning` → P1；其他 → P2（前端映射）。
+- `stage` 状态机：`pending → acknowledged → handled → archived`；**非法迁移返回 `409 CONFLICT`**。
+
+**`POST /alerts/batch-handle`**：
+
+```json
+{ "alertIds": ["alert_001", "alert_002"], "action": "ack" }
+```
+
+- `action` 合法值：`ack` / `handle` / `archive`（对应单条端点的动词）。
+- **当前后端实现 Bug**：校验使用 `pending/acknowledged/…` 而分支判断 `ack/…`，**需修复为统一 `ack/handle/archive`**（与契约一致）。
+- Response：
+
+```json
+{
+  "updated": 2,
+  "errors": [{ "id": "alert_003", "error": "CONFLICT", "currentStage": "handled" }]
+}
+```
+
+---
+
+### 3.6 围栏（`/fences`）
+
+| 状态 | Method | Path | 说明 |
+|------|--------|------|------|
+| ✅ | `GET` | `/fences` | 列表 |
+| ✅ | `GET` | `/fences/:id` | 详情 |
+| ✅ | `POST` | `/fences` | 创建 |
+| ✅ | `PUT` | `/fences/:id` | 更新 |
+| ✅ | `DELETE` | `/fences/:id` | 删除 |
+
+**`Fence` 字段**：
+
+```json
+{
+  "id": "fence_001",
+  "name": "A 区草场",
+  "type": "polygon",
+  "alarmEnabled": true,
+  "status": "active",
+  "coordinates": [[87.62, 43.81], [87.63, 43.82], [87.63, 43.80]],
+  "version": 3
+}
+```
+
+- `type`：`polygon` / `circle` / `rectangle`。
+- `coordinates`：`[lng, lat]` 对数组，多边形要求 ≥ 3 个点；圆形/矩形的坐标含义由 `type` 确定（Phase 2 明确）。
+- `status`：`active` / `inactive`。
+- **`version` 字段必须新增**：用于并发更新时判断冲突（PUT 时带上旧 version，服务端比较后再写）。不匹配返回 `409 CONFLICT`。
+- **返回字段补充**：`livestockCount`（可选，由服务端基于 `animals.fenceId` 聚合）、`areaHectares`（Phase 2）。
+
+**Create / Update Body**：
+
+```json
+{
+  "name": "A 区草场",
+  "type": "polygon",
+  "coordinates": [[87.62, 43.81], "..."],
+  "alarmEnabled": true,
+  "status": "active"
+}
+```
+
+**Delete Response `data`**：返回被删除围栏完整对象（App `fence_form_page` 依赖回显）。
+
+---
+
+### 3.7 租户（`/tenants`）
+
+| 状态 | Method | Path | Phase | 说明 |
+|------|--------|------|-------|------|
+| ✅ | `GET` | `/tenants` | 1 | 列表 |
+| ⚪ | `GET` | `/tenants/:id` | 1 | 详情（`ApiCache.fetchTenantDetail` 已实现但 App 尚未使用） |
+| ✅ | `POST` | `/tenants` | 1 | 创建 |
+| ✅ | `PUT` | `/tenants/:id` | 1 | 更新（当前仅 `name`） |
+| ✅ | `DELETE` | `/tenants/:id` | 1 | 删除 |
+| ✅ | `POST` | `/tenants/:id/status` | 1 | 启用/禁用 |
+| ✅ | `POST` | `/tenants/:id/license` | 1 | 调整配额 |
+| 🔴 | `GET` | `/tenants/:id/devices` | 2 | 设备列表（详情页卡片） |
+| 🔴 | `GET` | `/tenants/:id/logs` | 2 | 操作日志 |
+| 🔴 | `GET` | `/tenants/:id/stats` | 2 | 统计概览 |
+
+**Phase 1 `Tenant` 字段**：
+
+```json
+{
+  "id": "tenant_001",
+  "name": "示例牧场",
+  "status": "active",
+  "licenseUsed": 38,
+  "licenseTotal": 100
+}
+```
+
+**Phase 2 扩展字段**（后端 seed 先行补齐）：
+
+```json
+{
+  "contactName": "张三",
+  "contactPhone": "13800000000",
+  "contactEmail": "zhang@example.com",
+  "region": "新疆-伊犁",
+  "remarks": "xxx",
+  "createdAt": "2026-04-01T10:00:00+08:00",
+  "updatedAt": "2026-04-20T09:15:00+08:00",
+  "lastUpdatedBy": "user_ops"
+}
+```
+
+**`GET /tenants` Query**：
+
+| 参数 | 类型 | 默认 | 说明 |
+|------|------|------|------|
+| `page` / `pageSize` | int | 1 / 20 | 分页 |
+| `status` | enum | - | `active` / `disabled` / 缺省表示全部 |
+| `search` | string | - | 名称模糊匹配（Phase 1 仅 name，Phase 2 可含联系人） |
+| `sort` | enum | `licenseUsage` | `name` / `licenseUsage` / `createdAt`（Phase 2） / `updatedAt`（Phase 2） |
+| `order` | enum | `desc` | `asc` / `desc` |
+
+**写操作 Body 契约**（严格对齐前端）：
+
+| Path | Body |
+|------|------|
+| `POST /tenants` | `{ "name": "...", "licenseTotal": 100 }` |
+| `PUT /tenants/:id` | `{ "name": "..." }`（Phase 2 增加联系人/备注） |
+| `POST /tenants/:id/status` | `{ "status": "active" \| "disabled" }` |
+| `POST /tenants/:id/license` | `{ "licenseTotal": 200 }` — **参数名禁止使用 `newQuota`** |
+| `DELETE /tenants/:id` | 无 body；支持 query `reason=...`（Phase 2 写入日志） |
+
+**删除返回**：`data: { id }` 或完整租户对象（建议返回完整对象以便 App 即时显示"已删除"态）。
+
+---
+
+### 3.8 设备（`/devices`）
+
+| 状态 | Method | Path | Phase | 说明 |
+|------|--------|------|-------|------|
+| 🟡 | `GET` | `/devices` | 1 | 列表（权限应为 `device:view`，现复用 `dashboard:view`） |
+| 🔴 | `GET` | `/devices/:id` | 2 | 详情 |
+| 🔴 | `POST` | `/devices/:id/bind` | 2 | 绑定/更换耳标 |
+
+**`DeviceItem` 字段**：
+
+```json
+{
+  "id": "dev_gps_001",
+  "name": "GPS-001",
+  "type": "gps",
+  "status": "online",
+  "boundEarTag": "SL-2024-001",
+  "batteryPercent": 82,
+  "signalStrength": 4,
+  "lastSync": "2026-04-21T09:55:00+08:00"
+}
+```
+
+- `type`：`gps` / `rumenCapsule` / `accelerometer`。
+- `status`：`online` / `offline` / `lowBattery`。
+- `signalStrength`：0-5 格。
+
+---
+
+### 3.9 牲畜（`/livestock`）🔴 全部未实现
+
+| 状态 | Method | Path | Phase | 说明 |
+|------|--------|------|-------|------|
+| 🔴 | `GET` | `/livestock` | 2 | 列表（分页/筛选） |
+| 🔴 | `GET` | `/livestock/:earTag` | 1 | 详情（App `LiveLivestockRepository` 占位需求） |
+| 🔴 | `PUT` | `/livestock/:earTag` | 2 | 更新基础信息 |
+
+**`LivestockDetail` Response `data`**（映射 `LivestockDetail`）：
+
+```json
+{
+  "earTag": "SL-2024-001",
+  "livestockId": "0001",
+  "breed": "西门塔尔",
+  "ageMonths": 18,
+  "weightKg": 420,
+  "health": "healthy",
+  "fenceId": "fence_001",
+  "lat": 43.81,
+  "lng": 87.62,
+  "devices": [
+    { "id": "dev_gps_001", "type": "gps", "status": "online" }
+  ],
+  "bodyTemp": 38.5,
+  "activityLevel": "normal",
+  "ruminationFreq": 62,
+  "lastLocation": {
+    "lat": 43.81, "lng": 87.62, "timestamp": "2026-04-21T09:55:00+08:00"
+  }
+}
+```
+
+- `health`：`healthy` / `watch` / `abnormal`。
+
+---
+
+### 3.10 统计（`/stats`）🔴 全部未实现
+
+| 状态 | Method | Path | Phase | 说明 |
+|------|--------|------|-------|------|
+| 🔴 | `GET` | `/stats/health` | 2 | 健康摘要 |
+| 🔴 | `GET` | `/stats/alerts` | 2 | 告警摘要 |
+| 🔴 | `GET` | `/stats/devices` | 2 | 设备摘要 |
+
+**Query**：`timeRange`（`7d` / `30d` / `90d`）。
+
+**`/stats/health` `data`**（对齐 `StatsHealthSummary`）：
+
+```json
+{
+  "totalLivestock": 1280,
+  "healthyCount": 1200,
+  "watchCount": 56,
+  "abnormalCount": 24,
+  "trend": [ { "date": "2026-04-14", "healthyRate": 0.93 } ]
+}
+```
+
+**`/stats/alerts` `data`**：
+
+```json
+{
+  "totalAlerts": 156,
+  "byStage": { "pending": 12, "acknowledged": 22, "handled": 90, "archived": 32 },
+  "byLevel": { "critical": 14, "warning": 92, "info": 50 },
+  "trend": [ { "date": "2026-04-14", "count": 10 } ]
+}
+```
+
+**`/stats/devices` `data`**：
+
+```json
+{
+  "totalDevices": 100,
+  "onlineCount": 88,
+  "offlineCount": 8,
+  "lowBatteryCount": 4,
+  "byType": { "gps": 50, "rumenCapsule": 30, "accelerometer": 20 }
+}
+```
+
+---
+
+### 3.11 数字孪生（`/twin`）
+
+| 状态 | Method | Path | 说明 |
+|------|--------|------|------|
+| ✅ | `GET` | `/twin/overview` | 总览（指标 + 场景摘要 + 待办） |
+| ✅ | `GET` | `/twin/fever/list` | 体温异常列表 |
+| ✅ | `GET` | `/twin/fever/:id` | 体温详情 |
+| ✅ | `GET` | `/twin/digestive/list` | 消化健康列表 |
+| ✅ | `GET` | `/twin/digestive/:id` | 消化详情 |
+| ✅ | `GET` | `/twin/estrus/list` | 发情列表 |
+| ✅ | `GET` | `/twin/estrus/:id` | 发情详情 |
+| ✅ | `GET` | `/twin/epidemic/summary` | 疫病摘要 |
+| ✅ | `GET` | `/twin/epidemic/contacts` | 接触追踪 |
+
+**`/twin/overview` `data`**：
+
+```json
+{
+  "stats": {
+    "totalLivestock": 1280,
+    "healthyRate": 0.94,
+    "alertCount": 12,
+    "criticalCount": 2,
+    "deviceOnlineRate": 0.88,
+    "livestockCaption": "在栏 1280 头",
+    "alertCaption": "待处理 12 条",
+    "healthCaption": "健康率 94%",
+    "deviceCaption": "在线 88%",
+    "healthTrend": [0.92, 0.93, 0.94, "..."],
+    "livestockTrend": [1270, 1275, 1280, "..."]
+  },
+  "sceneSummary": {
+    "fever":     { "abnormalCount": 4, "criticalCount": 1 },
+    "digestive": { "abnormalCount": 3, "watchCount": 8 },
+    "estrus":    { "highScoreCount": 5, "breedingAdvice": true },
+    "epidemic":  { "status": "safe", "abnormalRate": 0.02 }
+  },
+  "pastureBanner": { "headline": "...", "detail": "..." },
+  "pendingTasks": [
+    {
+      "id": "task_001",
+      "title": "处理 4 条体温告警",
+      "subtitle": "最近 24 小时",
+      "routePath": "/fever",
+      "severity": "high"
+    }
+  ]
+}
+```
+
+**`/twin/fever/list` 每项**：
+
+```json
+{
+  "livestockId": "1017",
+  "baselineTemp": 38.5,
+  "threshold": 39.5,
+  "recent72h": [ { "temperature": 38.7, "timestamp": "2026-04-21T09:00:00+08:00" } ],
+  "status": "abnormal",
+  "conclusion": "持续升高，建议巡查"
+}
+```
+
+**`/twin/digestive/list` 每项**：
+
+```json
+{
+  "livestockId": "1017",
+  "motilityBaseline": 60,
+  "status": "watch",
+  "advice": "关注反刍节律",
+  "recent24h": [ { "frequency": 58, "intensity": 0.7, "timestamp": "..." } ]
+}
+```
+
+**`/twin/estrus/list` 每项**：
+
+```json
+{
+  "livestockId": "1017",
+  "score": 0.82,
+  "stepIncreasePercent": 0.35,
+  "tempDelta": 0.4,
+  "distanceDelta": 1200,
+  "timestamp": "2026-04-21T08:00:00+08:00",
+  "advice": "建议安排配种",
+  "trend7d": [ { "score": 0.7, "timestamp": "2026-04-15T08:00:00+08:00" } ]
+}
+```
+
+**`/twin/epidemic/summary` `data`**：
+
+```json
+{
+  "avgTemperature": 38.6,
+  "avgActivity": 1.2,
+  "abnormalRate": 0.02,
+  "totalLivestock": 1280,
+  "abnormalCount": 24
+}
+```
+
+**`/twin/epidemic/contacts` 每项**：
+
+```json
+{
+  "fromId": "animal_001",
+  "toId": "animal_017",
+  "lastContact": "2026-04-20T15:30:00+08:00",
+  "proximity": 0.4
+}
+```
+
+---
+
+## 4. 端点差距汇总（需立即补齐）
+
+### Phase 1（MVP 必需）
+
+| 端点 | 目的 | 阻塞功能 |
+|------|------|----------|
+| `GET /livestock/:earTag` | 牲畜详情 | `LiveLivestockRepository` 联调 |
+| `GET /me` 与 `/profile` 字段对齐 | 消除两端点重复 | 我的页 |
+| `POST /alerts/batch-handle` 修复 `action` 值 | 契约一致性 | 批量处理 |
+
+### Phase 2（扩展）
+
+| 端点 | 目的 |
+|------|------|
+| `GET /tenants/:id/{devices,logs,stats}` | 租户详情页 Phase 2 卡片 |
+| `GET /stats/{health,alerts,devices}` | 统计页 |
+| `GET /livestock` + `PUT /livestock/:earTag` | 牲畜列表与编辑 |
+| `GET /devices/:id` + `POST /devices/:id/bind` | 设备详情与绑定 |
+| 租户 seed 扩展字段 | 联系人/地区/备注/时间戳 |
+
+### 非端点契约缺口
+
+1. **`API_ROLE` 与登录角色不一致**：App 预加载固定用 `API_ROLE`，但租户写操作使用 Session 的 role。应改为登录后获取真实 Token，不再区分两套角色来源。
+2. **告警/租户 ID 命名风格不一致**：seed 中 `alert-001`、`animal_001` 混用。联调前需统一为下划线风格（见 §1.4）。
+3. **租户 `licenseUsed` 计算口径**：当前 seed 手写，未来应由后端基于 `animals` 表按 `tenantId` 聚合后计算。
+4. **围栏并发保护缺失**：无 `version` 字段，当前多人编辑可能互相覆盖。
+
+---
+
+## 5. 验收标准
+
+- 所有 Phase 1 端点在 Postman/HTTP 级测试（Supertest）下返回包络 + 错误码均符合 §1.2 / §1.6。
+- `mobile_app` 在 `APP_MODE=live` 下完成以下闭环：
+  - 登录 → 预加载 → 看板/地图/告警/围栏/租户/我的/孪生首页均可渲染。
+  - 租户创建、状态切换、License 调整、删除后列表即时刷新。
+  - 围栏创建、编辑、删除后地图同步刷新。
+  - 告警状态迁移与批量处理成功，非法迁移返回 409。
+- 所有响应字段名、枚举值、分页结构与本文 §3 一致，**不得在联调过程中私自改名**。
+
+---
+
+**契约版本**：v1.0（代码落地版）
+**生成日期**：2026-04-21
+**来源**：mobile_app + backend 现状 + `2026-04-20-tenant-management-design.md`

--- a/Mobile/docs/api-contracts/api-compatibility-matrix.md
+++ b/Mobile/docs/api-contracts/api-compatibility-matrix.md
@@ -1,0 +1,18 @@
+# API 兼容矩阵
+
+## 策略
+
+- `/api/v1` 是规范契约源。
+- `/api` 是面向现有客户端与回滚场景的长期兼容入口。
+- `/api` 必须与 `/api/v1` 共享后端实现；只允许适配层差异。
+
+## 矩阵
+
+| 模块 | `/api` 兼容承诺 | `/api/v1` 契约 | 负责人 | 测试状态 | 最后复核 |
+|------|-----------------|----------------|--------|----------|----------|
+| auth / me / profile | 保留登录、刷新、登出、`/me`、`/profile` | 规范源 | Backend | Planned | 2026-04-26 |
+| tenant | 保留 Phase 1 CRUD、状态、许可 | 规范源 | Backend | Planned | 2026-04-26 |
+| fence | 保留列表、详情、创建、更新、删除 | 规范源 | Backend | Planned | 2026-04-26 |
+| alert | 保留列表、单条状态流转、批量处理 | 规范源 | Backend | Planned | 2026-04-26 |
+| dashboard / map / devices / twin | 保留当前 live 预加载端点 | 规范源 | Backend | Planned | 2026-04-26 |
+| stats / livestock extension | 默认不回迁 | 规范源 | TBD | Not started | 2026-04-26 |

--- a/Mobile/mobile_app/lib/app/session/app_session.dart
+++ b/Mobile/mobile_app/lib/app/session/app_session.dart
@@ -1,13 +1,33 @@
 import 'package:smart_livestock_demo/core/models/demo_role.dart';
 
 class AppSession {
-  const AppSession._({this.role});
+  const AppSession._({
+    this.role,
+    this.accessToken,
+    this.refreshToken,
+    this.expiresAt,
+  });
 
   const AppSession.loggedOut() : this._();
 
   const AppSession.authenticated(DemoRole role) : this._(role: role);
 
+  const AppSession.withTokens({
+    required DemoRole role,
+    required String accessToken,
+    String? refreshToken,
+    DateTime? expiresAt,
+  }) : this._(
+          role: role,
+          accessToken: accessToken,
+          refreshToken: refreshToken,
+          expiresAt: expiresAt,
+        );
+
   final DemoRole? role;
+  final String? accessToken;
+  final String? refreshToken;
+  final DateTime? expiresAt;
 
   bool get isLoggedIn => role != null;
 

--- a/Mobile/mobile_app/lib/app/session/session_controller.dart
+++ b/Mobile/mobile_app/lib/app/session/session_controller.dart
@@ -10,6 +10,20 @@ class SessionController extends Notifier<AppSession> {
     state = AppSession.authenticated(role);
   }
 
+  void loginWithTokens({
+    required DemoRole role,
+    required String accessToken,
+    String? refreshToken,
+    DateTime? expiresAt,
+  }) {
+    state = AppSession.withTokens(
+      role: role,
+      accessToken: accessToken,
+      refreshToken: refreshToken,
+      expiresAt: expiresAt,
+    );
+  }
+
   void logout() {
     state = const AppSession.loggedOut();
   }

--- a/Mobile/mobile_app/lib/core/api/api_auth.dart
+++ b/Mobile/mobile_app/lib/core/api/api_auth.dart
@@ -1,0 +1,28 @@
+import 'package:smart_livestock_demo/core/models/demo_role.dart';
+
+class ApiAuthTokens {
+  const ApiAuthTokens({
+    this.accessToken,
+    this.refreshToken,
+    this.expiresAt,
+  });
+
+  final String? accessToken;
+  final String? refreshToken;
+  final DateTime? expiresAt;
+}
+
+Map<String, String> apiHeaders({
+  required DemoRole role,
+  ApiAuthTokens? tokens,
+  bool allowMockTokenFallback = false,
+}) {
+  final accessToken = tokens?.accessToken;
+  final authorizationValue =
+      accessToken ?? (allowMockTokenFallback ? 'mock-token-${role.name}' : null);
+  return {
+    'Content-Type': 'application/json',
+    if (authorizationValue != null)
+      'Authorization': 'Bearer $authorizationValue',
+  };
+}

--- a/Mobile/mobile_app/lib/core/api/api_cache.dart
+++ b/Mobile/mobile_app/lib/core/api/api_cache.dart
@@ -1,6 +1,9 @@
 import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
+import 'package:smart_livestock_demo/core/api/api_auth.dart';
+import 'package:smart_livestock_demo/core/api/api_http_client.dart';
+import 'package:smart_livestock_demo/core/models/demo_role.dart';
 
 const String _apiBaseUrlFromEnv = String.fromEnvironment(
   'API_BASE_URL',
@@ -11,14 +14,22 @@ String resolveApiBaseUrl() {
   if (_apiBaseUrlFromEnv.isNotEmpty) {
     return _apiBaseUrlFromEnv;
   }
-  return kIsWeb ? 'http://127.0.0.1:3001/api' : 'http://localhost:3001/api';
+  return kIsWeb
+      ? 'http://127.0.0.1:3001/api/v1'
+      : 'http://localhost:3001/api/v1';
 }
 
-Map<String, String> _headers(String role) {
-  return {
-    'Authorization': 'Bearer mock-token-$role',
-    'Content-Type': 'application/json',
-  };
+Map<String, String> _headers(
+  String role, {
+  ApiAuthTokens? tokens,
+  bool allowMockTokenFallback = false,
+  Map<String, ApiAuthTokens> roleTokens = const {},
+}) {
+  return apiHeaders(
+    role: DemoRole.values.byName(role),
+    tokens: tokens ?? roleTokens[role],
+    allowMockTokenFallback: allowMockTokenFallback,
+  );
 }
 
 String fenceSaveErrorMessageForStatusCode(int? statusCode) {
@@ -60,6 +71,10 @@ class ApiCache {
 
   bool _initialized = false;
   bool get initialized => _initialized;
+  String? _lastLiveSource;
+  String? get lastLiveSource => _lastLiveSource;
+  ApiHttpClient _httpClient = const DefaultApiHttpClient();
+  final Map<String, ApiAuthTokens> _roleTokens = {};
 
   List<Map<String, dynamic>> _dashboardMetrics = [];
   List<Map<String, dynamic>> _animals = [];
@@ -93,8 +108,57 @@ class ApiCache {
   List<Map<String, dynamic>> get epidemicContacts => _epidemicContacts;
   List<Map<String, dynamic>> get devices => _devices;
 
-  Future<void> init(String role) async {
-    final headers = _headers(role);
+  Future<ApiAuthTokens?> authenticateRole(String role) async {
+    final response = await _httpClient.post(
+      Uri.parse('${resolveApiBaseUrl()}/auth/login'),
+      headers: const {'Content-Type': 'application/json'},
+      body: jsonEncode({'role': role}),
+    );
+    if (response.statusCode != 200) {
+      return null;
+    }
+    final body = jsonDecode(response.body) as Map<String, dynamic>;
+    if (body['code'] != 'OK') {
+      return null;
+    }
+    final data = body['data'];
+    if (data is! Map<String, dynamic>) {
+      return null;
+    }
+    final accessToken = data['accessToken'];
+    if (accessToken is! String || accessToken.isEmpty) {
+      return null;
+    }
+    final expiresAtRaw = data['expiresAt'];
+    final tokens = ApiAuthTokens(
+      accessToken: accessToken,
+      refreshToken: data['refreshToken'] as String?,
+      expiresAt: expiresAtRaw is String ? DateTime.tryParse(expiresAtRaw) : null,
+    );
+    _roleTokens[role] = tokens;
+    return tokens;
+  }
+
+  Future<void> initWithRoleAuth(String role) async {
+    final tokens = await authenticateRole(role);
+    if (tokens == null) {
+      debugPrint('ApiCache auth failed for role: $role');
+      return;
+    }
+    await init(role, tokens: tokens);
+  }
+
+  Future<void> init(
+    String role, {
+    ApiAuthTokens? tokens,
+    bool allowMockTokenFallback = false,
+  }) async {
+    final headers = _headers(
+      role,
+      tokens: tokens,
+      allowMockTokenFallback: allowMockTokenFallback,
+      roleTokens: _roleTokens,
+    );
 
     try {
       final results = await Future.wait([
@@ -113,6 +177,11 @@ class ApiCache {
         _get('/devices?pageSize=200', headers),
       ]);
 
+      if (results.every((data) => data == null)) {
+        _initialized = false;
+        return;
+      }
+
       final dashData = results[0];
       if (dashData != null) {
         _dashboardMetrics =
@@ -121,28 +190,24 @@ class ApiCache {
 
       final mapData = results[1];
       if (mapData != null) {
-        _animals =
-            List<Map<String, dynamic>>.from(mapData['animals'] ?? []);
+        _animals = List<Map<String, dynamic>>.from(mapData['animals'] ?? []);
         _mapTrajectoryPoints =
             List<Map<String, dynamic>>.from(mapData['points'] ?? []);
       }
 
       final alertsData = results[2];
       if (alertsData != null) {
-        _alerts =
-            List<Map<String, dynamic>>.from(alertsData['items'] ?? []);
+        _alerts = List<Map<String, dynamic>>.from(alertsData['items'] ?? []);
       }
 
       final fencesData = results[3];
       if (fencesData != null) {
-        _fences =
-            List<Map<String, dynamic>>.from(fencesData['items'] ?? []);
+        _fences = List<Map<String, dynamic>>.from(fencesData['items'] ?? []);
       }
 
       final tenantsData = results[4];
       if (tenantsData != null) {
-        _tenants =
-            List<Map<String, dynamic>>.from(tenantsData['items'] ?? []);
+        _tenants = List<Map<String, dynamic>>.from(tenantsData['items'] ?? []);
       }
 
       _profile = results[5];
@@ -151,8 +216,7 @@ class ApiCache {
 
       final feverData = results[7];
       if (feverData != null) {
-        _feverList =
-            List<Map<String, dynamic>>.from(feverData['items'] ?? []);
+        _feverList = List<Map<String, dynamic>>.from(feverData['items'] ?? []);
       }
 
       final digestiveData = results[8];
@@ -177,8 +241,7 @@ class ApiCache {
 
       final devicesData = results[12];
       if (devicesData != null) {
-        _devices =
-            List<Map<String, dynamic>>.from(devicesData['items'] ?? []);
+        _devices = List<Map<String, dynamic>>.from(devicesData['items'] ?? []);
       }
 
       _initialized = true;
@@ -191,33 +254,51 @@ class ApiCache {
     String path,
     Map<String, String> headers,
   ) async {
-    final response = await http
-        .get(
-          Uri.parse('${resolveApiBaseUrl()}$path'),
-          headers: headers,
-        )
-        .timeout(const Duration(seconds: 20));
+    final response = await _httpClient.get(
+      Uri.parse('${resolveApiBaseUrl()}$path'),
+      headers: headers,
+    );
     if (response.statusCode == 200) {
       final body = jsonDecode(response.body) as Map<String, dynamic>;
       if (body['code'] == 'OK') {
+        _lastLiveSource = 'api';
         return body['data'] as Map<String, dynamic>?;
       }
     }
     return null;
   }
 
-  Future<void> refreshTenants(String role) async {
-    final headers = _headers(role);
+  Future<void> refreshTenants(
+    String role, {
+    ApiAuthTokens? tokens,
+    bool allowMockTokenFallback = false,
+  }) async {
+    final headers = _headers(
+      role,
+      tokens: tokens,
+      allowMockTokenFallback: allowMockTokenFallback,
+      roleTokens: _roleTokens,
+    );
     final data = await _get('/tenants?pageSize=100', headers);
     if (data != null) {
       _tenants = List<Map<String, dynamic>>.from(data['items'] ?? []);
     }
   }
 
-  Future<Map<String, dynamic>?> fetchTenantDetail(String role, String id) async {
+  Future<Map<String, dynamic>?> fetchTenantDetail(
+    String role,
+    String id, {
+    ApiAuthTokens? tokens,
+    bool allowMockTokenFallback = false,
+  }) async {
     final response = await http
         .get(Uri.parse('${resolveApiBaseUrl()}/tenants/$id'),
-            headers: _headers(role))
+            headers: _headers(
+              role,
+              tokens: tokens,
+              allowMockTokenFallback: allowMockTokenFallback,
+              roleTokens: _roleTokens,
+            ))
         .timeout(const Duration(seconds: 20));
     if (response.statusCode == 200) {
       final body = jsonDecode(response.body) as Map<String, dynamic>;
@@ -230,12 +311,19 @@ class ApiCache {
 
   Future<TenantWriteResult> createTenantRemote(
     String role,
-    Map<String, dynamic> body,
-  ) async {
+    Map<String, dynamic> body, {
+    ApiAuthTokens? tokens,
+    bool allowMockTokenFallback = false,
+  }) async {
     final response = await http
         .post(
           Uri.parse('${resolveApiBaseUrl()}/tenants'),
-          headers: _headers(role),
+          headers: _headers(
+            role,
+            tokens: tokens,
+            allowMockTokenFallback: allowMockTokenFallback,
+            roleTokens: _roleTokens,
+          ),
           body: jsonEncode(body),
         )
         .timeout(const Duration(seconds: 20));
@@ -245,12 +333,19 @@ class ApiCache {
   Future<TenantWriteResult> updateTenantRemote(
     String role,
     String id,
-    Map<String, dynamic> body,
-  ) async {
+    Map<String, dynamic> body, {
+    ApiAuthTokens? tokens,
+    bool allowMockTokenFallback = false,
+  }) async {
     final response = await http
         .put(
           Uri.parse('${resolveApiBaseUrl()}/tenants/$id'),
-          headers: _headers(role),
+          headers: _headers(
+            role,
+            tokens: tokens,
+            allowMockTokenFallback: allowMockTokenFallback,
+            roleTokens: _roleTokens,
+          ),
           body: jsonEncode(body),
         )
         .timeout(const Duration(seconds: 20));
@@ -260,12 +355,19 @@ class ApiCache {
   Future<TenantWriteResult> toggleTenantStatusRemote(
     String role,
     String id,
-    String status,
-  ) async {
+    String status, {
+    ApiAuthTokens? tokens,
+    bool allowMockTokenFallback = false,
+  }) async {
     final response = await http
         .post(
           Uri.parse('${resolveApiBaseUrl()}/tenants/$id/status'),
-          headers: _headers(role),
+          headers: _headers(
+            role,
+            tokens: tokens,
+            allowMockTokenFallback: allowMockTokenFallback,
+            roleTokens: _roleTokens,
+          ),
           body: jsonEncode({'status': status}),
         )
         .timeout(const Duration(seconds: 20));
@@ -275,23 +377,40 @@ class ApiCache {
   Future<TenantWriteResult> adjustTenantLicenseRemote(
     String role,
     String id,
-    int licenseTotal,
-  ) async {
+    int licenseTotal, {
+    ApiAuthTokens? tokens,
+    bool allowMockTokenFallback = false,
+  }) async {
     final response = await http
         .post(
           Uri.parse('${resolveApiBaseUrl()}/tenants/$id/license'),
-          headers: _headers(role),
+          headers: _headers(
+            role,
+            tokens: tokens,
+            allowMockTokenFallback: allowMockTokenFallback,
+            roleTokens: _roleTokens,
+          ),
           body: jsonEncode({'licenseTotal': licenseTotal}),
         )
         .timeout(const Duration(seconds: 20));
     return _parseTenantWrite(response);
   }
 
-  Future<TenantWriteResult> deleteTenantRemote(String role, String id) async {
+  Future<TenantWriteResult> deleteTenantRemote(
+    String role,
+    String id, {
+    ApiAuthTokens? tokens,
+    bool allowMockTokenFallback = false,
+  }) async {
     final response = await http
         .delete(
           Uri.parse('${resolveApiBaseUrl()}/tenants/$id'),
-          headers: _headers(role),
+          headers: _headers(
+            role,
+            tokens: tokens,
+            allowMockTokenFallback: allowMockTokenFallback,
+            roleTokens: _roleTokens,
+          ),
         )
         .timeout(const Duration(seconds: 20));
     return _parseTenantWrite(response);
@@ -318,30 +437,47 @@ class ApiCache {
     }
   }
 
-  Future<void> refreshFencesAndMap(String role) async {
-    final headers = _headers(role);
+  Future<void> refreshFencesAndMap(
+    String role, {
+    ApiAuthTokens? tokens,
+    bool allowMockTokenFallback = false,
+  }) async {
+    final headers = _headers(
+      role,
+      tokens: tokens,
+      allowMockTokenFallback: allowMockTokenFallback,
+      roleTokens: _roleTokens,
+    );
     final fencesData = await _get('/fences?pageSize=100', headers);
     if (fencesData != null) {
-      _fences =
-          List<Map<String, dynamic>>.from(fencesData['items'] ?? []);
+      _fences = List<Map<String, dynamic>>.from(fencesData['items'] ?? []);
     }
     final mapData = await _get(
       '/map/trajectories?animalId=animal_001&range=24h',
       headers,
     );
     if (mapData != null) {
-      _animals =
-          List<Map<String, dynamic>>.from(mapData['animals'] ?? []);
+      _animals = List<Map<String, dynamic>>.from(mapData['animals'] ?? []);
       _mapTrajectoryPoints =
           List<Map<String, dynamic>>.from(mapData['points'] ?? []);
     }
   }
 
-  Future<bool> deleteFenceRemote(String role, String id) async {
+  Future<bool> deleteFenceRemote(
+    String role,
+    String id, {
+    ApiAuthTokens? tokens,
+    bool allowMockTokenFallback = false,
+  }) async {
     final response = await http
         .delete(
           Uri.parse('${resolveApiBaseUrl()}/fences/$id'),
-          headers: _headers(role),
+          headers: _headers(
+            role,
+            tokens: tokens,
+            allowMockTokenFallback: allowMockTokenFallback,
+            roleTokens: _roleTokens,
+          ),
         )
         .timeout(const Duration(seconds: 20));
     if (response.statusCode == 200) {
@@ -353,8 +489,10 @@ class ApiCache {
 
   Future<bool> createFenceRemote(
     String role,
-    Map<String, dynamic> body,
-  ) async {
+    Map<String, dynamic> body, {
+    ApiAuthTokens? tokens,
+    bool allowMockTokenFallback = false,
+  }) async {
     if (createFenceRemoteOverride != null) {
       final result = await createFenceRemoteOverride!(role, body);
       lastFenceSaveStatusCode = result.ok ? null : result.statusCode;
@@ -363,7 +501,12 @@ class ApiCache {
     final response = await http
         .post(
           Uri.parse('${resolveApiBaseUrl()}/fences'),
-          headers: _headers(role),
+          headers: _headers(
+            role,
+            tokens: tokens,
+            allowMockTokenFallback: allowMockTokenFallback,
+            roleTokens: _roleTokens,
+          ),
           body: jsonEncode(body),
         )
         .timeout(const Duration(seconds: 20));
@@ -382,8 +525,10 @@ class ApiCache {
   Future<bool> updateFenceRemote(
     String role,
     String id,
-    Map<String, dynamic> body,
-  ) async {
+    Map<String, dynamic> body, {
+    ApiAuthTokens? tokens,
+    bool allowMockTokenFallback = false,
+  }) async {
     if (updateFenceRemoteOverride != null) {
       final result = await updateFenceRemoteOverride!(role, id, body);
       lastFenceSaveStatusCode = result.ok ? null : result.statusCode;
@@ -392,7 +537,12 @@ class ApiCache {
     final response = await http
         .put(
           Uri.parse('${resolveApiBaseUrl()}/fences/$id'),
-          headers: _headers(role),
+          headers: _headers(
+            role,
+            tokens: tokens,
+            allowMockTokenFallback: allowMockTokenFallback,
+            roleTokens: _roleTokens,
+          ),
           body: jsonEncode(body),
         )
         .timeout(const Duration(seconds: 20));
@@ -419,12 +569,46 @@ class ApiCache {
     Map<String, dynamic> body,
   )? updateFenceRemoteOverride;
 
+  @visibleForTesting
+  static Map<String, String> headersForTesting({
+    required DemoRole role,
+    ApiAuthTokens? tokens,
+    bool allowMockTokenFallback = false,
+  }) {
+    return apiHeaders(
+      role: role,
+      tokens: tokens,
+      allowMockTokenFallback: allowMockTokenFallback,
+    );
+  }
+
   int? lastFenceSaveStatusCode;
 
   @visibleForTesting
   void debugReset() {
     _initialized = false;
+    _lastLiveSource = null;
+    _httpClient = const DefaultApiHttpClient();
+    _roleTokens.clear();
+    _dashboardMetrics = [];
+    _animals = [];
+    _mapTrajectoryPoints = [];
+    _alerts = [];
+    _fences = [];
     _tenants = [];
+    _profile = null;
+    _twinOverview = null;
+    _feverList = [];
+    _digestiveList = [];
+    _estrusList = [];
+    _epidemicSummary = null;
+    _epidemicContacts = [];
+    _devices = [];
+  }
+
+  @visibleForTesting
+  void debugSetHttpClient(ApiHttpClient client) {
+    _httpClient = client;
   }
 
   @visibleForTesting

--- a/Mobile/mobile_app/lib/core/api/api_http_client.dart
+++ b/Mobile/mobile_app/lib/core/api/api_http_client.dart
@@ -1,0 +1,51 @@
+import 'package:http/http.dart' as http;
+
+class ApiHttpResponse {
+  const ApiHttpResponse(this.statusCode, this.body, this.headers);
+
+  final int statusCode;
+  final String body;
+  final Map<String, String> headers;
+}
+
+abstract class ApiHttpClient {
+  Future<ApiHttpResponse> get(Uri uri, {Map<String, String>? headers});
+
+  Future<ApiHttpResponse> post(
+    Uri uri, {
+    Map<String, String>? headers,
+    Object? body,
+  });
+}
+
+class DefaultApiHttpClient implements ApiHttpClient {
+  const DefaultApiHttpClient();
+
+  @override
+  Future<ApiHttpResponse> get(Uri uri, {Map<String, String>? headers}) async {
+    final response = await http
+        .get(uri, headers: headers)
+        .timeout(const Duration(seconds: 20));
+    return ApiHttpResponse(
+      response.statusCode,
+      response.body,
+      response.headers,
+    );
+  }
+
+  @override
+  Future<ApiHttpResponse> post(
+    Uri uri, {
+    Map<String, String>? headers,
+    Object? body,
+  }) async {
+    final response = await http
+        .post(uri, headers: headers, body: body)
+        .timeout(const Duration(seconds: 20));
+    return ApiHttpResponse(
+      response.statusCode,
+      response.body,
+      response.headers,
+    );
+  }
+}

--- a/Mobile/mobile_app/lib/main.dart
+++ b/Mobile/mobile_app/lib/main.dart
@@ -25,6 +25,6 @@ void main() async {
 
   if (appMode.isLive) {
     const apiRole = String.fromEnvironment('API_ROLE', defaultValue: 'owner');
-    unawaited(ApiCache.instance.init(apiRole));
+    unawaited(ApiCache.instance.initWithRoleAuth(apiRole));
   }
 }

--- a/Mobile/mobile_app/test/api_auth_test.dart
+++ b/Mobile/mobile_app/test/api_auth_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:smart_livestock_demo/core/api/api_auth.dart';
+import 'package:smart_livestock_demo/core/api/api_cache.dart';
+import 'package:smart_livestock_demo/core/models/demo_role.dart';
+
+void main() {
+  test('apiHeaders prefers access token', () {
+    final headers = apiHeaders(
+      role: DemoRole.owner,
+      tokens: const ApiAuthTokens(accessToken: 'jwt-token'),
+    );
+    expect(headers['Authorization'], 'Bearer jwt-token');
+  });
+
+  test('apiHeaders can use mock token fallback', () {
+    final headers = apiHeaders(role: DemoRole.worker);
+    expect(headers['Authorization'], isNull);
+  });
+
+  test('apiHeaders uses mock token only when fallback is enabled', () {
+    final headers = apiHeaders(
+      role: DemoRole.worker,
+      allowMockTokenFallback: true,
+    );
+    expect(headers['Authorization'], 'Bearer mock-token-worker');
+  });
+
+  test('ApiCache headers use token helper semantics', () {
+    final headers = ApiCache.headersForTesting(
+      role: DemoRole.owner,
+      tokens: const ApiAuthTokens(accessToken: 'jwt-token'),
+    );
+    expect(headers['Authorization'], 'Bearer jwt-token');
+  });
+
+  test('ApiCache headers do not send mock-token when fallback is disabled', () {
+    final headers = ApiCache.headersForTesting(role: DemoRole.owner);
+    expect(headers['Authorization'], isNull);
+  });
+}

--- a/Mobile/mobile_app/test/api_base_url_test.dart
+++ b/Mobile/mobile_app/test/api_base_url_test.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:smart_livestock_demo/core/api/api_cache.dart';
+
+void main() {
+  test('resolveApiBaseUrl defaults to versioned API', () {
+    expect(resolveApiBaseUrl(), contains('/api/v1'));
+  });
+
+  test('ApiCache starts without mock fallback source marker', () {
+    ApiCache.instance.debugReset();
+    expect(ApiCache.instance.lastLiveSource, isNull);
+  });
+}

--- a/Mobile/mobile_app/test/api_live_contract_test.dart
+++ b/Mobile/mobile_app/test/api_live_contract_test.dart
@@ -1,0 +1,179 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:smart_livestock_demo/core/api/api_auth.dart';
+import 'package:smart_livestock_demo/core/api/api_cache.dart';
+import 'package:smart_livestock_demo/core/api/api_http_client.dart';
+
+class RecordingApiHttpClient implements ApiHttpClient {
+  final uris = <Uri>[];
+  final postUris = <Uri>[];
+  final authHeaders = <String?>[];
+
+  @override
+  Future<ApiHttpResponse> get(Uri uri, {Map<String, String>? headers}) async {
+    uris.add(uri);
+    authHeaders.add(headers?['Authorization']);
+    return ApiHttpResponse(
+      200,
+      jsonEncode({
+        'code': 'OK',
+        'message': 'success',
+        'requestId': 'req_test',
+        'data': _dataFor(uri.path),
+      }),
+      {'x-api-version': 'v1'},
+    );
+  }
+
+  @override
+  Future<ApiHttpResponse> post(
+    Uri uri, {
+    Map<String, String>? headers,
+    Object? body,
+  }) async {
+    postUris.add(uri);
+    return ApiHttpResponse(
+      200,
+      jsonEncode({
+        'code': 'OK',
+        'message': 'success',
+        'requestId': 'req_auth',
+        'data': {
+          'token': 'mock-token-owner',
+          'role': 'owner',
+          'accessToken': 'jwt-token',
+          'refreshToken': 'refresh-token',
+          'expiresAt': '2999-01-01T00:00:00.000Z',
+          'user': {'role': 'owner'},
+        },
+      }),
+      {'x-api-version': 'v1'},
+    );
+  }
+
+  Map<String, dynamic> _dataFor(String path) {
+    if (path.endsWith('/dashboard/summary')) {
+      return {
+        'metrics': [
+          {'id': 'metric_001'},
+        ],
+      };
+    }
+    if (path.endsWith('/map/trajectories')) {
+      return {
+        'animals': [
+          {'id': 'animal_001'},
+        ],
+        'points': [
+          {'id': 'point_001'},
+        ],
+      };
+    }
+    if (path.endsWith('/alerts') ||
+        path.endsWith('/fences') ||
+        path.endsWith('/tenants') ||
+        path.endsWith('/devices')) {
+      return {
+        'items': [
+          {'id': 'item_001'},
+        ],
+        'page': 1,
+        'pageSize': 20,
+        'total': 1,
+      };
+    }
+    if (path.contains('/twin/') &&
+        !path.endsWith('/overview') &&
+        !path.endsWith('/summary')) {
+      return {
+        'items': [
+          {'id': 'twin_item_001'},
+        ],
+      };
+    }
+    return {'id': 'object_001'};
+  }
+}
+
+void main() {
+  test('ApiCache live init requests v1 endpoints with access token', () async {
+    final client = RecordingApiHttpClient();
+    ApiCache.instance.debugReset();
+    ApiCache.instance.debugSetHttpClient(client);
+
+    await ApiCache.instance.init(
+      'owner',
+      tokens: const ApiAuthTokens(accessToken: 'jwt-token'),
+      allowMockTokenFallback: false,
+    );
+
+    final requestedPaths = client.uris.map((uri) {
+      return uri.hasQuery ? '${uri.path}?${uri.query}' : uri.path;
+    });
+
+    expect(client.uris, isNotEmpty);
+    expect(client.uris, hasLength(13));
+    expect(
+      requestedPaths,
+      containsAll([
+        '/api/v1/dashboard/summary',
+        '/api/v1/map/trajectories?animalId=animal_001&range=24h',
+        '/api/v1/alerts?pageSize=100',
+        '/api/v1/fences?pageSize=100',
+        '/api/v1/tenants?pageSize=100',
+        '/api/v1/profile',
+        '/api/v1/twin/overview',
+        '/api/v1/twin/fever/list',
+        '/api/v1/twin/digestive/list',
+        '/api/v1/twin/estrus/list',
+        '/api/v1/twin/epidemic/summary',
+        '/api/v1/twin/epidemic/contacts',
+        '/api/v1/devices?pageSize=200',
+      ]),
+    );
+    expect(client.uris.every((uri) => uri.path.startsWith('/api/v1/')), isTrue);
+    expect(
+      client.authHeaders.every((value) => value == 'Bearer jwt-token'),
+      isTrue,
+    );
+    expect(ApiCache.instance.initialized, isTrue);
+    expect(ApiCache.instance.lastLiveSource, 'api');
+
+    ApiCache.instance.debugReset();
+    expect(ApiCache.instance.initialized, isFalse);
+    expect(ApiCache.instance.lastLiveSource, isNull);
+    expect(ApiCache.instance.dashboardMetrics, isEmpty);
+    expect(ApiCache.instance.animals, isEmpty);
+    expect(ApiCache.instance.mapTrajectoryPoints, isEmpty);
+    expect(ApiCache.instance.alerts, isEmpty);
+    expect(ApiCache.instance.fences, isEmpty);
+    expect(ApiCache.instance.tenants, isEmpty);
+    expect(ApiCache.instance.profile, isNull);
+    expect(ApiCache.instance.twinOverview, isNull);
+    expect(ApiCache.instance.feverList, isEmpty);
+    expect(ApiCache.instance.digestiveList, isEmpty);
+    expect(ApiCache.instance.estrusList, isEmpty);
+    expect(ApiCache.instance.epidemicSummary, isNull);
+    expect(ApiCache.instance.epidemicContacts, isEmpty);
+    expect(ApiCache.instance.devices, isEmpty);
+  });
+
+  test('ApiCache can authenticate role before live init', () async {
+    final client = RecordingApiHttpClient();
+    ApiCache.instance.debugReset();
+    ApiCache.instance.debugSetHttpClient(client);
+
+    await ApiCache.instance.initWithRoleAuth('owner');
+
+    expect(client.postUris, hasLength(1));
+    expect(client.postUris.single.path, '/api/v1/auth/login');
+    expect(client.uris, hasLength(13));
+    expect(
+      client.authHeaders.every((value) => value == 'Bearer jwt-token'),
+      isTrue,
+    );
+    expect(ApiCache.instance.initialized, isTrue);
+    expect(ApiCache.instance.lastLiveSource, 'api');
+  });
+}


### PR DESCRIPTION
## Summary
- Add shared `/api` and `/api/v1` backend routing with request IDs, version headers, and route-equivalence tests.
- Add JWT-first mock auth, refresh/logout support, controlled mock-token fallback, and aligned `/me`/`/profile` projections.
- Switch Flutter live defaults to `/api/v1`, add token-aware API headers, live auth preloading, source markers, and compatibility docs.

## Test plan
- [x] `npm --prefix Mobile/backend test`
- [x] `flutter test test/api_auth_test.dart test/api_base_url_test.dart test/api_live_contract_test.dart test/app_mode_switch_test.dart`
- [x] `flutter analyze`
- [x] Backend smoke: `/api/v1/auth/login` + `/api/v1/me`


Made with [Cursor](https://cursor.com)