### PR TITLE
fix: livestockCode fallback to earTag when livestockCode absent

### DIFF
--- a/Mobile/mobile_app/lib/features/livestock/data/livestock_api_repository.dart
+++ b/Mobile/mobile_app/lib/features/livestock/data/livestock_api_repository.dart
@@ -78,9 +78,9 @@ class LivestockApiRepository implements LivestockRepository {
             .toList()
         : <String>[];
     return LivestockSummary(
-      id: id,
-    livestockCode: m['livestockCode'] as String? ?? '',
-      breed: Breed.fromString(m['breed'] as String?),
+     id: id,
+    livestockCode: m['livestockCode'] as String? ?? m['earTag'] as String? ?? '',
+     breed: Breed.fromString(m['breed'] as String?),
       health: health,
       fenceId: (m['fenceId'] ?? '').toString(),
       lat: (m['lastLatitude'] as num?)?.toDouble(),


### PR DESCRIPTION
## 问题

Flutter CI 失败（PR #67 合并后持续报红）：415 tests passed, 1 failed。

失败的测试：
```
LivestockApiRepository._livestockSummaryFromMap earTag fallback from earTag when livestockCode absent
Expected: 'EAR-001'
  Actual: ''
```

## 根因

`_livestockSummaryFromMap` 中 `livestockCode` 字段缺失时直接回退为空字符串 `''`，没有尝试从 `earTag` 回退。

## 修复

```diff
-    livestockCode: m['livestockCode'] as String? ?? '',
+    livestockCode: m['livestockCode'] as String? ?? m['earTag'] as String? ?? '',
```

## 验证

- [x] `flutter test test/features/livestock/livestock_api_repository_test.dart` — 18/18 通过
- [ ] CI 全量测试通过