### PR TITLE
fix(NIX-7): 移动轨迹地图使用 SmartTileProvider 三级降级替代硬编码 OSM

### DIFF
--- a/Mobile/mobile_app/lib/features/livestock/presentation/widgets/trajectory_sheet.dart
+++ b/Mobile/mobile_app/lib/features/livestock/presentation/widgets/trajectory_sheet.dart
@@ -36,6 +36,9 @@ class _TrajectorySheetState extends ConsumerState<_TrajectorySheet> {
   List<Map<String, dynamic>> _points = [];
   bool _loading = true;
   SmartTileProvider? _tileProvider;
+  final _mapController = MapController();
+  bool _lastTransformed = false;
+  LatLngBounds? _lastBounds;
 
   @override
   void initState() {
@@ -57,6 +60,7 @@ class _TrajectorySheetState extends ConsumerState<_TrajectorySheet> {
   @override
   void dispose() {
     _tileProvider?.dispose();
+    _mapController.dispose();
     super.dispose();
   }
 
@@ -188,12 +192,31 @@ class _TrajectorySheetState extends ConsumerState<_TrajectorySheet> {
     final distance = totalPathDistance(sampled);
     final bounds = LatLngBounds.fromPoints(latLngs);
 
+    // initialCameraFit only fires on the first FlutterMap build. When the
+    // tile source switches (OSM → 高德) the coordinate system changes
+    // (WGS-84 → GCJ-02) so we must re-fit the camera to stay centred.
+    if (_lastTransformed != shouldTransform) {
+      _lastTransformed = shouldTransform;
+      _lastBounds = bounds;
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted && _lastBounds != null) {
+          _mapController.fitCamera(
+            CameraFit.bounds(
+              bounds: _lastBounds!,
+              padding: const EdgeInsets.all(40),
+            ),
+          );
+        }
+      });
+    }
+
     return Column(
       children: [
         Expanded(
           child: ClipRRect(
             borderRadius: BorderRadius.circular(8),
             child: FlutterMap(
+              mapController: _mapController,
               options: MapOptions(
                 initialCameraFit: CameraFit.bounds(
                   bounds: bounds,

--- a/Mobile/mobile_app/lib/features/livestock/presentation/widgets/trajectory_sheet.dart
+++ b/Mobile/mobile_app/lib/features/livestock/presentation/widgets/trajectory_sheet.dart
@@ -6,6 +6,9 @@ import 'package:hkt_livestock_agentic/core/models/core_models.dart';
 import 'package:hkt_livestock_agentic/core/theme/app_colors.dart';
 import 'package:hkt_livestock_agentic/core/theme/app_spacing.dart';
 import 'package:hkt_livestock_agentic/core/utils/geo_utils.dart';
+import 'package:hkt_livestock_agentic/core/map/smart_tile_provider.dart';
+import 'package:hkt_livestock_agentic/core/map/smart_tile_factory.dart';
+import 'package:hkt_livestock_agentic/core/map/coord_transform.dart';
 import 'package:hkt_livestock_agentic/l10n/gen/app_localizations.dart';
 import 'package:latlong2/latlong.dart';
 
@@ -32,11 +35,29 @@ class _TrajectorySheetState extends ConsumerState<_TrajectorySheet> {
   _TimeRange _range = _TimeRange.h24;
   List<Map<String, dynamic>> _points = [];
   bool _loading = true;
+  SmartTileProvider? _tileProvider;
 
   @override
   void initState() {
     super.initState();
+    _initTileProvider();
     _load();
+  }
+
+  Future<void> _initTileProvider() async {
+    _tileProvider = await loadSmartTileProvider(
+      ref,
+      onSourceChanged: () {
+        if (mounted) setState(() {});
+      },
+    );
+    if (mounted) setState(() {});
+  }
+
+  @override
+  void dispose() {
+    _tileProvider?.dispose();
+    super.dispose();
   }
 
   Future<void> _load() async {
@@ -156,7 +177,14 @@ class _TrajectorySheetState extends ConsumerState<_TrajectorySheet> {
         .where((p) => p.lat != 0.0 || p.lng != 0.0)
         .toList();
     final sampled = downsample(rawPoints, 500);
-    final latLngs = sampled.map((p) => LatLng(p.lat, p.lng)).toList();
+    var latLngs = sampled.map((p) => LatLng(p.lat, p.lng)).toList();
+    // Transform WGS-84 GPS points to GCJ-02 when using 高德 fallback tiles
+    // so the trajectory aligns with the map.
+    final shouldTransform =
+        _tileProvider?.shouldTransformCoordinates() ?? false;
+    if (shouldTransform) {
+      latLngs = CoordTransform.wgs84ToGcj02All(latLngs);
+    }
     final distance = totalPathDistance(sampled);
     final bounds = LatLngBounds.fromPoints(latLngs);
 
@@ -174,8 +202,8 @@ class _TrajectorySheetState extends ConsumerState<_TrajectorySheet> {
               ),
               children: [
                 TileLayer(
-                  urlTemplate:
-                      'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+                  tileProvider: _tileProvider,
+                  urlTemplate: '',
                 ),
                 PolylineLayer(
                   polylines: [


### PR DESCRIPTION
## 修复 NIX-7：移动轨迹中看不到地图

### 问题
移动轨迹页面（trajectory_sheet.dart）硬编码了 OSM 瓦片 URL `https://tile.openstreetmap.org/{z}/{x}/{y}.png`，未接入项目的 SmartTileProvider 三级降级机制（tileserver-gl → MBTiles → 高德/OSM）。

当 OSM 在中国被墙时，牧场主地图能降级到高德正常显示，但移动轨迹页仍用 OSM → 瓦片加载失败 → **看不到地图**。

### 根因
```dart
// 修改前 — 硬编码 OSM，无法降级
TileLayer(
  urlTemplate: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
),
```

### 修复方案
与 ranch_page / fence_form_page 等其他地图页面对齐，统一使用 SmartTileProvider：

1. **接入 `loadSmartTileProvider()`**：替代硬编码 OSM TileLayer，实现三级降级
2. **坐标转换**：降级到高德(GCJ-02)瓦片时，通过 `shouldTransformCoordinates()` 判断，将 GPS WGS-84 轨迹点转换为 GCJ-02 以对齐地图
3. **生命周期管理**：添加 `dispose()` 释放 SmartTileProvider 资源
4. **自动刷新**：`onSourceChanged` 回调确保瓦片源切换时自动重建

### 验证
- `flutter analyze` ✅（新增代码无 issue）
- 编译验证 ✅

### 影响范围
仅修改 `trajectory_sheet.dart` 1 个文件，+31/-3 行。

Closes NIX-7