### PR TITLE
fix(NIX-16): 未激活设备绑定到牲畜显示友好错误提示

### DIFF
--- a/Mobile/mobile_app/lib/core/api/api_exception.dart
+++ b/Mobile/mobile_app/lib/core/api/api_exception.dart
@@ -6,6 +6,11 @@ sealed class ApiException implements Exception {
   final String? code;
 
   const ApiException({required this.message, this.statusCode, this.code});
+
+  /// Returns [message] so that `e.toString()` in catch blocks displays the
+  /// backend-provided i18n message instead of "Instance of 'ConflictException'".
+  @override
+  String toString() => message;
 }
 
 class AuthException extends ApiException {


### PR DESCRIPTION
## 修复内容

### 根因
`ApiException` sealed class 未覆写 `toString()`，导致 catch 块中 `e.toString()` 返回 `"Instance of 'ConflictException'"` 而非后端返回的 i18n 错误消息。

### 错误链路
1. 用户绑定未激活设备到牲畜
2. 后端 `InstallationApplicationService.install()` 抛出 `DEVICE_NOT_ACTIVE`，返回 HTTP 409 + `{"message": "设备未激活，无法安装: 123"}`
3. 前端 `ApiClient._handleResponse` 抛出 `ConflictException(message: "设备未激活，无法安装: 123")`
4. 前端 catch 块 `e.toString()` → 返回 `"Instance of 'ConflictException'"`
5. 用户看到: **"安装失败: Instance of 'ConflictException'"** — 完全不友好

### 修复
在 `ApiException` 基类中覆写 `toString()` 返回 `message` 字段。一处改动修复所有调用点：
- `devices_page.dart` — 设备绑定到牲畜（NIX-16 核心）
- `devices_page.dart` — 设备解绑
- `livestock_detail_page.dart` — 牲畜详情页绑定设备
- `offline_tile_management_page.dart` — 离线瓦片下载

### 验证
- ✅ `flutter analyze` 无新 issue
- ✅ `flutter build web` 编译通过

Closes NIX-16