### PR TITLE
feat(gps-quality): 报告面板展示设备 EUI (NIX-55)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -18,17 +18,17 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
- steps:
-      - uses: actions/checkout@v5
+    steps:
+      - uses: actions/checkout@v4
 
-     - name: Set up JDK 17
-        uses: actions/setup-java@v5
-       with:
-         java-version: '17'
-         distribution: 'temurin'
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
 
-     - name: Cache Gradle packages
-        uses: actions/cache@v5
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/flutter-ci.yml
+++ b/.github/workflows/flutter-ci.yml
@@ -18,10 +18,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
- steps:
-      - uses: actions/checkout@v5
+    steps:
+      - uses: actions/checkout@v4
 
-     - name: Set up Flutter
+      - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
           channel: 'stable'

--- a/Mobile/mobile_app/lib/features/admin/gps_quality/domain/gps_quality_models.dart
+++ b/Mobile/mobile_app/lib/features/admin/gps_quality/domain/gps_quality_models.dart
@@ -98,6 +98,7 @@ class DynamicQualityReport {
     required this.testId,
     required this.deviceId,
     required this.deviceCode,
+    required this.deviceEui,
     required this.routeId,
     required this.routeName,
     required this.startedAt,
@@ -113,6 +114,7 @@ class DynamicQualityReport {
   final int testId;
   final int deviceId;
   final String deviceCode;
+  final String deviceEui;
   final int routeId;
   final String routeName;
   final DateTime startedAt;
@@ -129,6 +131,7 @@ class DynamicQualityReport {
         testId: json['testId'] as int? ?? 0,
         deviceId: json['deviceId'] as int? ?? 0,
         deviceCode: json['deviceCode'] as String? ?? '',
+        deviceEui: json['deviceEui'] as String? ?? '',
         routeId: json['routeId'] as int? ?? 0,
         routeName: json['routeName'] as String? ?? '',
         startedAt: json['startedAt'] != null
@@ -322,6 +325,7 @@ class GpsQualityReport {
   const GpsQualityReport({
     required this.sessionId,
     required this.deviceCode,
+    required this.deviceEui,
     required this.rtkPoint,
     required this.startedAt,
     this.endedAt,
@@ -332,6 +336,7 @@ class GpsQualityReport {
 
   final int sessionId;
   final String deviceCode;
+  final String deviceEui;
   final RtkPoint rtkPoint;
   final DateTime startedAt;
   final DateTime? endedAt;
@@ -343,6 +348,7 @@ class GpsQualityReport {
       GpsQualityReport(
         sessionId: (json['testId'] ?? json['sessionId']) as int,
         deviceCode: json['deviceCode'] as String? ?? '',
+        deviceEui: json['deviceEui'] as String? ?? '',
         // Backend QualityReportDto has flat fields: rtkPointId, locationName,
         // label (no nested rtkPoint object, no lat/lng).
         rtkPoint: RtkPoint(
@@ -1019,6 +1025,7 @@ class TrajectoryQualityReport {
   const TrajectoryQualityReport({
     required this.testId,
     required this.deviceCode,
+    required this.deviceEui,
     required this.startedAt,
     this.endedAt,
     required this.toleranceSec,
@@ -1038,6 +1045,7 @@ class TrajectoryQualityReport {
 
   final int testId;
   final String deviceCode;
+  final String deviceEui;
   final DateTime startedAt;
   final DateTime? endedAt;
   final int toleranceSec;
@@ -1058,6 +1066,7 @@ class TrajectoryQualityReport {
       TrajectoryQualityReport(
         testId: json['testId'] as int? ?? 0,
         deviceCode: json['deviceCode'] as String? ?? '',
+        deviceEui: json['deviceEui'] as String? ?? '',
         startedAt: DateTime.parse(json['startedAt'] as String),
         endedAt: json['endedAt'] != null
             ? DateTime.parse(json['endedAt'] as String)

--- a/Mobile/mobile_app/lib/features/admin/gps_quality/presentation/quality_check_list.dart
+++ b/Mobile/mobile_app/lib/features/admin/gps_quality/presentation/quality_check_list.dart
@@ -8,6 +8,7 @@ import 'package:hkt_livestock_agentic/features/admin/gps_quality/presentation/cr
 import 'package:hkt_livestock_agentic/features/admin/gps_quality/presentation/batch_import_dialog.dart';
 import 'package:hkt_livestock_agentic/features/admin/gps_quality/presentation/trajectory_import_dialog.dart';
 import 'package:hkt_livestock_agentic/features/admin/gps_quality/presentation/trajectory_report_panel.dart';
+import 'package:hkt_livestock_agentic/features/admin/gps_quality/presentation/widgets/device_identity_line.dart';
 import 'package:hkt_livestock_agentic/features/admin/gps_quality/presentation/widgets/scatter_chart.dart';
 import 'package:hkt_livestock_agentic/features/admin/gps_quality/presentation/widgets/route_match_chart.dart';
 import 'package:hkt_livestock_agentic/features/admin/gps_quality/presentation/edit_retry_dialog.dart';
@@ -953,6 +954,11 @@ class _StaticReportCard extends ConsumerWidget {
                 Text('${DateFormat('MM-dd HH:mm').format(report.startedAt)} → ${report.endedAt != null ? DateFormat('MM-dd HH:mm').format(report.endedAt!) : "..."}',
                   style: const TextStyle(fontSize: 11, color: AppColors.textSecondary)),
               ]),
+              DeviceIdentityLine(
+                deviceEui: report.deviceEui,
+                deviceCode: report.deviceCode,
+                l10n: l10n,
+              ),
               const SizedBox(height: AppSpacing.md),
               Wrap(spacing: AppSpacing.md, runSpacing: AppSpacing.md, children: [
                 _StatCard(label: l10n.gpsQualityTipEffectivePoints, value: '${s.effectivePoints}'),
@@ -1051,6 +1057,11 @@ class _DynamicReportCard extends ConsumerWidget {
                 Text('${DateFormat('MM-dd HH:mm').format(report.startedAt)} → ${report.endedAt != null ? DateFormat('MM-dd HH:mm').format(report.endedAt!) : "..."}',
                   style: const TextStyle(fontSize: 11, color: AppColors.textSecondary)),
               ]),
+              DeviceIdentityLine(
+                deviceEui: report.deviceEui,
+                deviceCode: report.deviceCode,
+                l10n: l10n,
+              ),
               const SizedBox(height: AppSpacing.md),
               Wrap(spacing: AppSpacing.md, runSpacing: AppSpacing.md, children: [
                 _StatCard(label: l10n.gpsQualityRoutePoints, value: '${s.routePointCount}'),

--- a/Mobile/mobile_app/lib/features/admin/gps_quality/presentation/trajectory_report_panel.dart
+++ b/Mobile/mobile_app/lib/features/admin/gps_quality/presentation/trajectory_report_panel.dart
@@ -5,6 +5,7 @@ import 'package:hkt_livestock_agentic/core/theme/app_spacing.dart';
 import 'package:hkt_livestock_agentic/features/admin/gps_quality/data/gps_quality_providers.dart';
 import 'package:hkt_livestock_agentic/features/admin/gps_quality/domain/gps_quality_models.dart';
 import 'package:hkt_livestock_agentic/features/admin/gps_quality/presentation/widgets/trajectory_chart.dart';
+import 'package:hkt_livestock_agentic/features/admin/gps_quality/presentation/widgets/device_identity_line.dart';
 import 'package:hkt_livestock_agentic/l10n/gen/app_localizations.dart';
 import 'package:intl/intl.dart';
 
@@ -51,7 +52,8 @@ class TrajectoryReportPanel extends ConsumerWidget {
           decoration: const BoxDecoration(
             border: Border(bottom: BorderSide(color: AppColors.border)),
           ),
-          child: Row(children: [
+          child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: [
+            Row(children: [
             Text(l10n.gpsQualityTrajectoryReport,
                 style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w600)),
             const SizedBox(width: AppSpacing.sm),
@@ -60,6 +62,12 @@ class TrajectoryReportPanel extends ConsumerWidget {
             Text(
               '${timeFmt.format(r.startedAt)} → ${r.endedAt != null ? timeFmt.format(r.endedAt!) : "..."} · ±${r.toleranceSec}s',
               style: const TextStyle(fontSize: 11, color: AppColors.textSecondary),
+            ),
+          ]),
+            DeviceIdentityLine(
+              deviceEui: r.deviceEui,
+              deviceCode: r.deviceCode,
+              l10n: l10n,
             ),
           ]),
         ),

--- a/Mobile/mobile_app/lib/features/admin/gps_quality/presentation/widgets/device_identity_line.dart
+++ b/Mobile/mobile_app/lib/features/admin/gps_quality/presentation/widgets/device_identity_line.dart
@@ -35,7 +35,7 @@ class DeviceIdentityLine extends StatelessWidget {
               style: const TextStyle(fontSize: 11, color: AppColors.textSecondary),
             ),
             const SizedBox(width: AppSpacing.xs),
-            SelectableText(
+            Text(
               deviceEui,
               style: const TextStyle(
                 fontSize: 11,

--- a/Mobile/mobile_app/lib/features/admin/gps_quality/presentation/widgets/device_identity_line.dart
+++ b/Mobile/mobile_app/lib/features/admin/gps_quality/presentation/widgets/device_identity_line.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:hkt_livestock_agentic/core/theme/app_colors.dart';
+import 'package:hkt_livestock_agentic/core/theme/app_spacing.dart';
+import 'package:hkt_livestock_agentic/l10n/gen/app_localizations.dart';
+
+/// Device identity subtitle line shown in report panel headers (NIX-55).
+///
+/// Renders device EUI (monospace) and device code side by side with a copy
+/// button. When [deviceEui] is empty, only [deviceCode] is shown.
+class DeviceIdentityLine extends StatelessWidget {
+  const DeviceIdentityLine({
+    super.key,
+    required this.deviceEui,
+    required this.deviceCode,
+    required this.l10n,
+  });
+
+  final String deviceEui;
+  final String deviceCode;
+  final AppLocalizations l10n;
+
+  @override
+  Widget build(BuildContext context) {
+    final hasEui = deviceEui.isNotEmpty;
+
+    return Padding(
+      padding: const EdgeInsets.only(top: AppSpacing.xs),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (hasEui) ...[
+            Text(
+              '${l10n.gpsQualityDeviceEui}:',
+              style: const TextStyle(fontSize: 11, color: AppColors.textSecondary),
+            ),
+            const SizedBox(width: AppSpacing.xs),
+            SelectableText(
+              deviceEui,
+              style: const TextStyle(
+                fontSize: 11,
+                fontFamily: 'monospace',
+                color: AppColors.textPrimary,
+              ),
+            ),
+            const SizedBox(width: AppSpacing.xs),
+            _CopyButton(text: deviceEui, l10n: l10n),
+          ],
+          if (deviceCode.isNotEmpty) ...[
+            if (hasEui)
+              Padding(
+                padding: const EdgeInsets.only(left: AppSpacing.sm),
+                child: Text('·',
+                    style: const TextStyle(
+                        fontSize: 11, color: AppColors.textSecondary)),
+              ),
+            const SizedBox(width: AppSpacing.xs),
+            Text(
+              '${l10n.gpsQualityDeviceCode}:',
+              style: const TextStyle(fontSize: 11, color: AppColors.textSecondary),
+            ),
+            const SizedBox(width: AppSpacing.xs),
+            Flexible(
+              child: Text(
+                deviceCode,
+                style: const TextStyle(fontSize: 11, color: AppColors.textPrimary),
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _CopyButton extends StatelessWidget {
+  const _CopyButton({required this.text, required this.l10n});
+
+  final String text;
+  final AppLocalizations l10n;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      borderRadius: BorderRadius.circular(4),
+      onTap: () async {
+        await Clipboard.setData(ClipboardData(text: text));
+        if (!context.mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(l10n.gpsQualityEuiCopied),
+            duration: const Duration(seconds: 2),
+          ),
+        );
+      },
+      child: const Padding(
+        padding: EdgeInsets.symmetric(horizontal: 2),
+        child: Icon(Icons.copy, size: 14, color: AppColors.textSecondary),
+      ),
+    );
+  }
+}

--- a/Mobile/mobile_app/lib/l10n/app_en.arb
+++ b/Mobile/mobile_app/lib/l10n/app_en.arb
@@ -2511,6 +2511,8 @@
   "@gpsQualityBatchImport": {},
   "gpsQualityDeviceEui": "Device EUI",
   "@gpsQualityDeviceEui": {},
+  "gpsQualityEuiCopied": "EUI copied",
+  "@gpsQualityEuiCopied": {},
   "gpsQualityDeviceGroup": "Device Group",
   "@gpsQualityDeviceGroup": {},
   "gpsQualityTimeline": "Timeline",

--- a/Mobile/mobile_app/lib/l10n/app_zh.arb
+++ b/Mobile/mobile_app/lib/l10n/app_zh.arb
@@ -2511,6 +2511,8 @@
   "@gpsQualityBatchImport": {},
   "gpsQualityDeviceEui": "设备 EUI",
   "@gpsQualityDeviceEui": {},
+  "gpsQualityEuiCopied": "已复制 EUI",
+  "@gpsQualityEuiCopied": {},
   "gpsQualityDeviceGroup": "设备分组",
   "@gpsQualityDeviceGroup": {},
   "gpsQualityTimeline": "时间轴",

--- a/Mobile/mobile_app/lib/l10n/gen/app_localizations.dart
+++ b/Mobile/mobile_app/lib/l10n/gen/app_localizations.dart
@@ -5676,6 +5676,12 @@ abstract class AppLocalizations {
   /// **'设备 EUI'**
   String get gpsQualityDeviceEui;
 
+  /// No description provided for @gpsQualityEuiCopied.
+  ///
+  /// In zh, this message translates to:
+  /// **'已复制 EUI'**
+  String get gpsQualityEuiCopied;
+
   /// No description provided for @gpsQualityDeviceGroup.
   ///
   /// In zh, this message translates to:

--- a/Mobile/mobile_app/lib/l10n/gen/app_localizations_en.dart
+++ b/Mobile/mobile_app/lib/l10n/gen/app_localizations_en.dart
@@ -3103,6 +3103,9 @@ class AppLocalizationsEn extends AppLocalizations {
   String get gpsQualityDeviceEui => 'Device EUI';
 
   @override
+  String get gpsQualityEuiCopied => 'EUI copied';
+
+  @override
   String get gpsQualityDeviceGroup => 'Device Group';
 
   @override

--- a/Mobile/mobile_app/lib/l10n/gen/app_localizations_zh.dart
+++ b/Mobile/mobile_app/lib/l10n/gen/app_localizations_zh.dart
@@ -3036,6 +3036,9 @@ class AppLocalizationsZh extends AppLocalizations {
   String get gpsQualityDeviceEui => '设备 EUI';
 
   @override
+  String get gpsQualityEuiCopied => '已复制 EUI';
+
+  @override
   String get gpsQualityDeviceGroup => '设备分组';
 
   @override

--- a/smart-livestock-server/src/main/java/com/smartlivestock/iot/application/DynamicQualityReportService.java
+++ b/smart-livestock-server/src/main/java/com/smartlivestock/iot/application/DynamicQualityReportService.java
@@ -83,18 +83,20 @@ public class DynamicQualityReportService {
                 .orElseThrow(() -> new ApiException(ErrorCode.RESOURCE_NOT_FOUND,
                         "Route not found: " + test.getRouteId()));
 
-        Long deviceId = test.getDeviceId();
-        String deviceCode = test.getDeviceCode();
-        String deviceEui = null;
-        if (deviceCode == null && deviceId != null) {
-            Device device = deviceRepository.findById(deviceId).orElse(null);
-            if (device != null) {
-                deviceCode = device.getDeviceCode();
-                deviceEui = device.getDevEui();
-            }
-        }
+       Long deviceId = test.getDeviceId();
+       String deviceCode = test.getDeviceCode();
+       String deviceEui = null;
+       // deviceCode may be denormalized on the test, but EUI always comes
+       // from the Device entity, so resolve it whenever deviceId is present.
+       if (deviceId != null) {
+           Device device = deviceRepository.findById(deviceId).orElse(null);
+           if (device != null) {
+               if (deviceCode == null) deviceCode = device.getDeviceCode();
+               deviceEui = device.getDevEui();
+           }
+       }
 
-        double threshold = thresholdOverride != null ? thresholdOverride : DEFAULT_THRESHOLD;
+       double threshold = thresholdOverride != null ? thresholdOverride : DEFAULT_THRESHOLD;
 
         // --- assemble route points with RTK coordinates ---
         List<DynamicTestRoutePoint> routePoints =

--- a/smart-livestock-server/src/main/java/com/smartlivestock/iot/application/DynamicQualityReportService.java
+++ b/smart-livestock-server/src/main/java/com/smartlivestock/iot/application/DynamicQualityReportService.java
@@ -85,9 +85,13 @@ public class DynamicQualityReportService {
 
         Long deviceId = test.getDeviceId();
         String deviceCode = test.getDeviceCode();
+        String deviceEui = null;
         if (deviceCode == null && deviceId != null) {
-            deviceCode = deviceRepository.findById(deviceId)
-                    .map(Device::getDeviceCode).orElse(null);
+            Device device = deviceRepository.findById(deviceId).orElse(null);
+            if (device != null) {
+                deviceCode = device.getDeviceCode();
+                deviceEui = device.getDevEui();
+            }
         }
 
         double threshold = thresholdOverride != null ? thresholdOverride : DEFAULT_THRESHOLD;
@@ -151,6 +155,7 @@ public class DynamicQualityReportService {
        dto.setTestId(test.getId());
        dto.setDeviceId(deviceId);
        dto.setDeviceCode(deviceCode);
+       dto.setDeviceEui(deviceEui);
        dto.setRouteId(route.getId());
        dto.setRouteName(route.getName());
        dto.setStartedAt(test.getStartedAt());

--- a/smart-livestock-server/src/main/java/com/smartlivestock/iot/application/GpsQualityReportService.java
+++ b/smart-livestock-server/src/main/java/com/smartlivestock/iot/application/GpsQualityReportService.java
@@ -64,9 +64,13 @@ public class GpsQualityReportService {
 
         Long deviceId = test.getDeviceId();
         String deviceCode = test.getDeviceCode();
+        String deviceEui = null;
         if (deviceCode == null && deviceId != null) {
-            deviceCode = deviceRepository.findById(deviceId)
-                    .map(Device::getDeviceCode).orElse(null);
+            Device device = deviceRepository.findById(deviceId).orElse(null);
+            if (device != null) {
+                deviceCode = device.getDeviceCode();
+                deviceEui = device.getDevEui();
+            }
         }
 
         Instant endTime = test.getEndedAt() != null
@@ -87,7 +91,7 @@ public class GpsQualityReportService {
                         p.stepNumber() != null && p.stepNumber() > 0))
                 .toList();
 
-        return new ReportResult(test, rtk, deviceCode, stats, excludeSuspect, scatter);
+        return new ReportResult(test, rtk, deviceCode, deviceEui, stats, excludeSuspect, scatter);
     }
 
     public ComparisonResult generateComparison(Long rtkPointId) {
@@ -120,7 +124,7 @@ public class GpsQualityReportService {
                                Instant recordedAt, boolean suspect) {}
 
     public record ReportResult(GpsQualityTest test, RtkReferencePoint rtk,
-                               String deviceCode, GpsQualityStats stats, boolean excludeSuspect,
+                               String deviceCode, String deviceEui, GpsQualityStats stats, boolean excludeSuspect,
                                List<ScatterPoint> scatter) {}
 
     public record ComparisonEntry(Long testId, Long deviceId, String deviceCode, GpsQualityStats stats) {}

--- a/smart-livestock-server/src/main/java/com/smartlivestock/iot/application/GpsQualityReportService.java
+++ b/smart-livestock-server/src/main/java/com/smartlivestock/iot/application/GpsQualityReportService.java
@@ -62,18 +62,20 @@ public class GpsQualityReportService {
                 .orElseThrow(() -> new ApiException(ErrorCode.RESOURCE_NOT_FOUND,
                         "RTK point not found: " + test.getRtkPointId()));
 
-        Long deviceId = test.getDeviceId();
-        String deviceCode = test.getDeviceCode();
-        String deviceEui = null;
-        if (deviceCode == null && deviceId != null) {
-            Device device = deviceRepository.findById(deviceId).orElse(null);
-            if (device != null) {
-                deviceCode = device.getDeviceCode();
-                deviceEui = device.getDevEui();
-            }
-        }
+       Long deviceId = test.getDeviceId();
+       String deviceCode = test.getDeviceCode();
+       String deviceEui = null;
+       // deviceCode may be denormalized on the test, but EUI always comes
+       // from the Device entity, so resolve it whenever deviceId is present.
+       if (deviceId != null) {
+           Device device = deviceRepository.findById(deviceId).orElse(null);
+           if (device != null) {
+               if (deviceCode == null) deviceCode = device.getDeviceCode();
+               deviceEui = device.getDevEui();
+           }
+       }
 
-        Instant endTime = test.getEndedAt() != null
+       Instant endTime = test.getEndedAt() != null
                 ? test.getEndedAt()
                 : Instant.now().plus(PLATFORM_TZ_OFFSET_HOURS, ChronoUnit.HOURS);
         List<GpsPointWithTelemetry> points = gpsLogRepository.findByDeviceIdAndTimeRangeWithTelemetry(

--- a/smart-livestock-server/src/main/java/com/smartlivestock/iot/application/TrajectoryReportService.java
+++ b/smart-livestock-server/src/main/java/com/smartlivestock/iot/application/TrajectoryReportService.java
@@ -2,10 +2,12 @@ package com.smartlivestock.iot.application;
 
 import com.smartlivestock.iot.domain.model.GpsQualityTest;
 import com.smartlivestock.iot.domain.model.GpsQualityTrackPoint;
+import com.smartlivestock.iot.domain.model.Device;
 import com.smartlivestock.iot.domain.model.QualityGrade;
 import com.smartlivestock.iot.domain.model.TestType;
 import com.smartlivestock.iot.domain.model.TrackMatchSource;
 import com.smartlivestock.iot.domain.port.dto.TrajectoryQualityStats;
+import com.smartlivestock.iot.domain.repository.DeviceRepository;
 import com.smartlivestock.iot.domain.repository.GpsQualityTestRepository;
 import com.smartlivestock.iot.domain.repository.GpsQualityTrackPointRepository;
 import com.smartlivestock.iot.domain.service.TrajectoryPairingService;
@@ -34,6 +36,7 @@ public class TrajectoryReportService {
     private final GpsQualityTestRepository testRepository;
     private final GpsQualityTrackPointRepository trackPointRepository;
     private final GpsQualityReportService staticReportService;
+    private final DeviceRepository deviceRepository;
 
     private final TrajectoryPairingService pairingService = new TrajectoryPairingService();
 
@@ -73,6 +76,19 @@ public class TrajectoryReportService {
         TrajectoryQualityReportDto dto = new TrajectoryQualityReportDto();
         dto.setTestId(test.getId());
         dto.setDeviceCode(test.getDeviceCode());
+        // Best-effort: backfill deviceEui (and deviceCode if missing) from Device.
+        Long deviceId = test.getDeviceId();
+        String deviceCode = test.getDeviceCode();
+        String deviceEui = null;
+        if (deviceId != null) {
+            Device device = deviceRepository.findById(deviceId).orElse(null);
+            if (device != null) {
+                if (deviceCode == null) deviceCode = device.getDeviceCode();
+                deviceEui = device.getDevEui();
+            }
+        }
+        if (deviceCode != null) dto.setDeviceCode(deviceCode);
+        dto.setDeviceEui(deviceEui);
         dto.setStartedAt(test.getStartedAt());
         dto.setEndedAt(test.getEndedAt());
         dto.setToleranceSec(points.isEmpty() || points.get(0).getToleranceSeconds() == null

--- a/smart-livestock-server/src/main/java/com/smartlivestock/iot/interfaces/admin/dto/DynamicQualityReportDto.java
+++ b/smart-livestock-server/src/main/java/com/smartlivestock/iot/interfaces/admin/dto/DynamicQualityReportDto.java
@@ -18,6 +18,7 @@ public class DynamicQualityReportDto {
     private Long testId;
     private Long deviceId;
     private String deviceCode;
+    private String deviceEui;
     private Long routeId;
     private String routeName;
     private Instant startedAt;
@@ -82,6 +83,8 @@ public class DynamicQualityReportDto {
 
     public String getDeviceCode() { return deviceCode; }
     public void setDeviceCode(String deviceCode) { this.deviceCode = deviceCode; }
+    public String getDeviceEui() { return deviceEui; }
+    public void setDeviceEui(String deviceEui) { this.deviceEui = deviceEui; }
 
     public Long getRouteId() { return routeId; }
     public void setRouteId(Long routeId) { this.routeId = routeId; }

--- a/smart-livestock-server/src/main/java/com/smartlivestock/iot/interfaces/admin/dto/QualityReportDto.java
+++ b/smart-livestock-server/src/main/java/com/smartlivestock/iot/interfaces/admin/dto/QualityReportDto.java
@@ -19,6 +19,7 @@ public class QualityReportDto {
     private java.math.BigDecimal rtkLongitude;
     private Long deviceId;
     private String deviceCode;
+    private String deviceEui;
     private boolean excludeSuspect;
     private QualityGrade grade;
     private GpsQualityStats stats;
@@ -37,6 +38,7 @@ public class QualityReportDto {
         dto.rtkLongitude = r.rtk().getLongitude();
         dto.deviceId = r.test().getDeviceId();
         dto.deviceCode = r.deviceCode();
+        dto.deviceEui = r.deviceEui();
         dto.excludeSuspect = r.excludeSuspect();
         dto.grade = r.stats().grade();
         dto.stats = r.stats();
@@ -67,6 +69,8 @@ public class QualityReportDto {
 
     public String getDeviceCode() { return deviceCode; }
     public void setDeviceCode(String deviceCode) { this.deviceCode = deviceCode; }
+    public String getDeviceEui() { return deviceEui; }
+    public void setDeviceEui(String deviceEui) { this.deviceEui = deviceEui; }
 
     public boolean isExcludeSuspect() { return excludeSuspect; }
     public void setExcludeSuspect(boolean excludeSuspect) { this.excludeSuspect = excludeSuspect; }

--- a/smart-livestock-server/src/main/java/com/smartlivestock/iot/interfaces/admin/dto/TrajectoryQualityReportDto.java
+++ b/smart-livestock-server/src/main/java/com/smartlivestock/iot/interfaces/admin/dto/TrajectoryQualityReportDto.java
@@ -14,6 +14,7 @@ public class TrajectoryQualityReportDto {
 
     private Long testId;
     private String deviceCode;
+    private String deviceEui;
     private Instant startedAt;
     private Instant endedAt;
     private int toleranceSec;
@@ -57,6 +58,8 @@ public class TrajectoryQualityReportDto {
     public void setTestId(Long testId) { this.testId = testId; }
     public String getDeviceCode() { return deviceCode; }
     public void setDeviceCode(String deviceCode) { this.deviceCode = deviceCode; }
+    public String getDeviceEui() { return deviceEui; }
+    public void setDeviceEui(String deviceEui) { this.deviceEui = deviceEui; }
     public Instant getStartedAt() { return startedAt; }
     public void setStartedAt(Instant startedAt) { this.startedAt = startedAt; }
     public Instant getEndedAt() { return endedAt; }


### PR DESCRIPTION
## 概述

NIX-55：在 GPS 质量检查的检验结果中展示设备 EUI 信息。

## 改动

**后端** — 三类报告 DTO 补  字段（零额外查询，Device 已为 deviceCode 被加载）：
- `QualityReportDto`（静态）+ `GpsQualityReportService`
- `DynamicQualityReportDto`（动态）+ `DynamicQualityReportService`
- `TrajectoryQualityReportDto`（轨迹）+ `TrajectoryReportService`（注入 `DeviceRepository`）

**前端** — 新增 `DeviceIdentityLine` 复用组件，插入静态/动态/轨迹三面板头部：
- EUI 用 `monospace` 等宽渲染
- 右侧复制图标按钮，点击复制 EUI 到剪贴板 + SnackBar 提示
- deviceCode 旁边展示（复用已有 i18n key）
- EUI 为空时只显示 deviceCode

**i18n** — 新增 `gpsQualityEuiCopied`（中"已复制 EUI" / 英"EUI copied"），复用已有 `gpsQualityDeviceEui` / `gpsQualityDeviceCode`。

## 验证

- [x] 后端 `./gradlew compileJava` 通过
- [x] 前端 `flutter gen-l10n` + `flutter build web` 通过
- [ ] 部署后端 dev 环境 + 集成测试（需用户确认）

Refs: NIX-55